### PR TITLE
put <pre>... </pre> tags around source code content in case cobertura/ dir

### DIFF
--- a/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
@@ -115,7 +115,7 @@
                                         <th colspan="3">${it.relativeSourcePath}</th>
                                     </tr>
                                 </thead>
-                                ${it.sourceFileContent}
+                                <pre>${it.sourceFileContent}</pre>
 
                             </table>
                         </div>


### PR DESCRIPTION
Not sure how one can view the source code file contents within Cobertura without it!  Otherwise the source code (if the cobertura/ directory is mapped correctly) just dumps all the code in one line.
