### PR TITLE
pull request to include support for 'cobertura-it-maven-plugin'

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -467,15 +467,16 @@ public class CoberturaPublisher extends Recorder {
     }
 
     private boolean didCoberturaRun(Iterable<MavenBuild> mavenBuilds) {
-      for(MavenBuild build: mavenBuilds) { 
+      for(MavenBuild build: mavenBuilds) {
         if(didCoberturaRun(build)) return true;
       }
       return false;
     }
-    
+
     private boolean didCoberturaRun(MavenBuild mavenBuild) {
       for(ExecutedMojo mojo : mavenBuild.getExecutedMojos()) {
-        if(mojo.groupId.equals("org.codehaus.mojo") && mojo.artifactId.equals("cobertura-maven-plugin")) {
+	  if(mojo.groupId.equals("org.codehaus.mojo") &&
+	     ( mojo.artifactId.equals("cobertura-maven-plugin") || mojo.artifactId.equals("cobertura-it-maven-plugin"))) {
           return true;
         }
       }

--- a/src/main/java/hudson/plugins/cobertura/MavenCoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/MavenCoberturaPublisher.java
@@ -208,7 +208,7 @@ public class MavenCoberturaPublisher extends MavenReporter {
 	}
 
 	private boolean isCoberturaReport(MojoInfo mojo) {
-		if (!mojo.pluginName.matches("org.codehaus.mojo", "cobertura-maven-plugin"))
+		if (!mojo.pluginName.matches("org.codehaus.mojo", "cobertura-maven-plugin") || !mojo.pluginName.matches("org.codehaus.mojo", "cobertura-it-maven-plugin"))
 			return false;
 
 		if (!mojo.getGoal().equals("cobertura"))


### PR DESCRIPTION
This fork of standard cobertura maven plugin allows more control
how to run the instrumentation during the 'intergration-test' phase
of the Maven project. For details check project's homepage:

  http://code.google.com/p/cobertura-it-maven-plugin/

As the name of the plugin differs slightly, this patch fixes that.
