### PR TITLE
Added "most recent N builds" limiting option for coverage graph.

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -68,6 +68,8 @@ public class CoberturaPublisher extends Recorder {
 
     private final boolean zoomCoverageChart;
     
+    private final int maxNumberOfBuilds;
+    
     private boolean failNoReports = true;
 
     private CoverageTarget healthyTarget;
@@ -86,7 +88,8 @@ public class CoberturaPublisher extends Recorder {
      */
     @DataBoundConstructor
     public CoberturaPublisher(String coberturaReportFile, boolean onlyStable, boolean failUnhealthy, boolean failUnstable, 
-            boolean autoUpdateHealth, boolean autoUpdateStability, boolean zoomCoverageChart, boolean failNoReports, SourceEncoding sourceEncoding) {
+            boolean autoUpdateHealth, boolean autoUpdateStability, boolean zoomCoverageChart, boolean failNoReports, SourceEncoding sourceEncoding,
+            int maxNumberOfBuilds) {
         this.coberturaReportFile = coberturaReportFile;
         this.onlyStable = onlyStable;
         this.failUnhealthy = failUnhealthy;
@@ -96,6 +99,7 @@ public class CoberturaPublisher extends Recorder {
         this.zoomCoverageChart = zoomCoverageChart;
         this.failNoReports = failNoReports;
         this.sourceEncoding = sourceEncoding;
+        this.maxNumberOfBuilds = maxNumberOfBuilds;
         this.healthyTarget = new CoverageTarget();
         this.unhealthyTarget = new CoverageTarget();
         this.failingTarget = new CoverageTarget();
@@ -197,6 +201,10 @@ public class CoberturaPublisher extends Recorder {
     public boolean getOnlyStable() {
         return onlyStable;
     }
+    
+    public int getMaxNumberOfBuilds() {
+		return maxNumberOfBuilds;
+	}
 
     /**
      * Getter for property 'failUnhealthy'.

--- a/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.jelly
@@ -32,6 +32,10 @@
              description="${%zoom.coverage.chart.description}" >
        <f:checkbox name="cobertura.zoomCoverageChart" checked="${instance.zoomCoverageChart}" />                                                                                        
     </f:entry>  
+    <f:entry title="${%Maximum number of builds}"
+             description="${%maxbuilds.coverage.chart.description}" >
+       <f:textbox name="cobertura.maxNumberOfBuilds" value="${instance.maxNumberOfBuilds}" />                                                                                        
+    </f:entry>  
     <f:entry title="${%Source Encoding}"
              description="${%source.encoding.description}" field="sourceEncoding">
        <f:enum>${it.encodingName}</f:enum>

--- a/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.properties
@@ -13,13 +13,8 @@ unstable.fail.builds.description=Unstable projects will be failed.
 auto.health.builds.description=Auto update threshold for health on successful build.
 auto.stability.builds.description=Auto update threshold for stability on successful build.
 zoom.coverage.chart.description=Zoom the coverage chart and crop area below the minimum and above the maximum coverage of the past reports.
-metric.targets.description=\
- Configure health reporting thresholds. <br/> \
- For the <img src="{0}/images/16x16/health-80plus.gif" alt="100%" /> \
- row, leave blank to use the default value (i.e. 80). <br/> \
- For the <img src="{0}/images/16x16/health-00to19.gif" alt="0%" /> and \
- <img src="{0}/images/16x16/yellow.gif" alt="0%" /> rows, leave blank to \
- use the default values (i.e. 0).
+maxbuilds.coverage.chart.description=Only graph the most recent N builds in the coverage chart, 0 disables the limit.
+metric.targets.description=Configure health reporting thresholds. <br/> For the <img src\="{0}/images/16x16/health-80plus.gif" alt\="100%" /> row, leave blank to use the default value (i.e. 80). <br/> For the <img src\="{0}/images/16x16/health-00to19.gif" alt\="0%" /> and <img src\="{0}/images/16x16/yellow.gif" alt\="0%" /> rows, leave blank to use the default values (i.e. 0).
 
 source.encoding.description=Encoding when showing files. 
 no.reorts.fail.builds.description=fail builds if No coverage reports are found.

--- a/src/test/java/hudson/plugins/cobertura/ChartTest.java
+++ b/src/test/java/hudson/plugins/cobertura/ChartTest.java
@@ -19,7 +19,7 @@ public class ChartTest
 	@Test(expected = NullPointerException.class)
 	public void noGraph() throws IOException
 	{
-		new CoverageChart( null, true );
+		new CoverageChart( null, true, 0 );
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -27,7 +27,7 @@ public class ChartTest
 	{
 		ctl = EasyMock.createControl();
 		CoverageResult result = new CoverageResultBuilder( ctl ).data().create();
-		new CoverageChart( result, true );
+		new CoverageChart( result, true, 0 );
 	}
 
 	@SuppressWarnings("unchecked")
@@ -36,7 +36,7 @@ public class ChartTest
 	{
 		ctl = EasyMock.createControl();
 		CoverageResult result = new CoverageResultBuilder( ctl ).data().data().create();
-		CoverageChart chartData = new CoverageChart( result, true );
+		CoverageChart chartData = new CoverageChart( result, true, 0 );
 		Assert.assertEquals( 74, chartData.getLowerBound() );
 		Assert.assertEquals( 101, chartData.getUpperBound() );
 		assertEquals( Arrays.asList( "#1", "#2" ), chartData.getDataset().getColumnKeys() );
@@ -54,7 +54,7 @@ public class ChartTest
 				.result( 100, 100, 200, 300, 400, 500 )//
 				.result( 100, 200, 300, 400, 500, 600 )//
 				.create();
-		CoverageChart chartData = new CoverageChart( result, true );
+		CoverageChart chartData = new CoverageChart( result, true, 0 );
 		Assert.assertEquals( 9, chartData.getLowerBound() );
 		Assert.assertEquals( 61, chartData.getUpperBound() );
 		assertEquals( Arrays.asList( "#1", "#2", "#3" ), chartData.getDataset().getColumnKeys() );
@@ -72,7 +72,7 @@ public class ChartTest
 				.result( 0 )//
 				.result( 1000 )//
 				.result( 1000 ).create();
-		CoverageChart chartData = new CoverageChart( result, true );
+		CoverageChart chartData = new CoverageChart( result, true, 0 );
 		Assert.assertEquals( -1, chartData.getLowerBound() );
 		Assert.assertEquals( 101, chartData.getUpperBound() );
 		assertEquals( Arrays.asList( "#1", "#2", "#3", "#4" ), chartData.getDataset().getColumnKeys() );
@@ -90,7 +90,7 @@ public class ChartTest
 				.result( 115 )//
 				.result( 108 )//
 				.result( 111, 108, 107, 114, 113, 109 ).create();
-		CoverageChart chartData = new CoverageChart( result, true );
+		CoverageChart chartData = new CoverageChart( result, true, 0 );
 		Assert.assertEquals( 10, chartData.getLowerBound() );
 		Assert.assertEquals( 12, chartData.getUpperBound() );
 		assertEquals( Arrays.asList( "#1", "#2", "#3", "#4" ), chartData.getDataset().getColumnKeys() );
@@ -107,7 +107,7 @@ public class ChartTest
 				.result( 115 )//
 				.result( 108 )//
 				.result( 111, 108, 107, 114, 113, 109 ).create();
-		CoverageChart chartData = new CoverageChart( result, false );
+		CoverageChart chartData = new CoverageChart( result, false, 0 );
 		Assert.assertEquals( -1, chartData.getLowerBound() );
 		Assert.assertEquals( 101, chartData.getUpperBound() );
 		assertEquals( Arrays.asList( "#1", "#2", "#3", "#4" ), chartData.getDataset().getColumnKeys() );

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherTest.java
@@ -8,40 +8,40 @@ public class CoberturaPublisherTest {
 
 	@Test
 	public void testGetOnlyStable() {
-		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, true, false, false, false, false, false, false, null);
-		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null);
+		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, true, false, false, false, false, false, false, null, 0);
+		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null, 0);
 		assertTrue(testObjectTrue.getOnlyStable());
 		assertTrue(!testObjectFalse.getOnlyStable());
 	}
 	
 	@Test
 	public void testGetFailUnhealthy() {
-		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, true, false, false, false, false, false, null);
-		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null);
+		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, true, false, false, false, false, false, null, 0);
+		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null, 0);
 		assertTrue(testObjectTrue.getFailUnhealthy());
 		assertTrue(!testObjectFalse.getFailUnhealthy());
 	}
 
 	@Test
 	public void testGetFailUnstable() {
-		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, true, false, false, false, false, null);
-		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null);
+		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, true, false, false, false, false, null, 0);
+		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null, 0);
 		assertTrue(testObjectTrue.getFailUnstable());
 		assertTrue(!testObjectFalse.getFailUnstable());
 	}
 
 	@Test
 	public void testGetAutoUpdateHealth() {
-		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, false, true, false, false, false, null);
-		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null);
+		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, false, true, false, false, false, null, 0);
+		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null, 0);
 		assertTrue(testObjectTrue.getAutoUpdateHealth());
 		assertTrue(!testObjectFalse.getAutoUpdateHealth());
 	}
 
 	@Test
 	public void testGetAutoUpdateStability() {
-		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, false, false, true, false, false, null);
-		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null);
+		CoberturaPublisher testObjectTrue = new CoberturaPublisher(null, false, false, false, false, true, false, false, null, 0);
+		CoberturaPublisher testObjectFalse = new CoberturaPublisher(null, false, false, false, false, false, false, false, null, 0);
 		assertTrue(testObjectTrue.getAutoUpdateStability());
 		assertTrue(!testObjectFalse.getAutoUpdateStability());
 	}


### PR DESCRIPTION
Hi,

I wrote this patch because the generation of coverage graphs is very slow (unusable, never finishes and eats cpu), because of the huge size of our project (40MB coverage xml file).

I realize that the real fix for this speed issue would need some kind of preprocessing of xml files into a database or a quickly parseable, indexed binary format. This is just a workaround which enables me to limit the number of builds taken into account. It could even have use cases if the speed wasn't an issue.
