### PR TITLE
[JENKINS-20706] Support matrix builds

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaMatrixAggregator.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaMatrixAggregator.java
@@ -1,0 +1,124 @@
+package hudson.plugins.cobertura;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import static hudson.plugins.cobertura.CoberturaPublisher.getCoberturaReports;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import hudson.plugins.cobertura.targets.CoverageTarget;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CoberturaMatrixAggregator extends MatrixAggregator {
+
+    private final CoberturaPublisher publisher;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param build the MatrixBuild to aggregate coverage for.
+     * @param launcher the launcher.
+     * @param listener the listener.
+     * @param publisher the CoberturaPublisher
+     */
+    public CoberturaMatrixAggregator(
+            MatrixBuild build,
+            Launcher launcher,
+            BuildListener listener,
+            CoberturaPublisher publisher) {
+        super(build, launcher, listener);
+        this.publisher = publisher;
+    }
+
+    @Override
+    public boolean endRun(MatrixRun run) {
+        FilePath rootBuildDir = new FilePath(build.getRootBuild().getRootDir());
+
+        for (File coberturaXmlReport : getCoberturaReports(run)) {
+            FilePath report = new FilePath(coberturaXmlReport.getAbsoluteFile());
+            final FilePath rootTargetPath = new FilePath(
+                rootBuildDir,
+                "coverage_" + run.getWorkspace().getBaseName() + ".xml"
+            );
+
+            try {
+                report.copyTo(rootTargetPath);
+            } catch (IOException ex) {
+                Logger.getLogger(CoberturaMatrixAggregator.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (InterruptedException ex) {
+                Logger.getLogger(CoberturaMatrixAggregator.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean endBuild() {
+        CoverageResult result = null;
+
+        for (File report : getCoberturaReports(build)) {
+            try {
+                result = CoberturaCoverageParser.parse(report, result);
+            } catch (IOException e) {
+                Util.displayIOException(e, listener);
+                e.printStackTrace(
+                    listener.fatalError("Unable to parse " + report)
+                );
+                build.setResult(Result.FAILURE);
+            }
+        }
+
+        if (result != null) {
+            result.setOwner(build);
+            build.addAction(
+                CoberturaBuildAction.load(
+                    build,
+                    result,
+                    this.getHealthyTarget(), this.getUnhealthyTarget(),
+                    this.getOnlyStable(),
+                    this.getFailUnhealthy(), this.getFailUnstable(),
+                    this.getAutoUpdateHealth(), this.getAutoUpdateStability()
+                )
+            );
+        }
+
+        return true;
+    }
+
+    private CoverageTarget getHealthyTarget() {
+        return this.publisher.getHealthyTarget();
+    }
+
+    private CoverageTarget getUnhealthyTarget() {
+        return this.publisher.getUnhealthyTarget();
+    }
+
+    private boolean getOnlyStable() {
+        return this.publisher.getOnlyStable();
+    }
+
+    private boolean getFailUnhealthy() {
+        return this.publisher.getFailUnhealthy();
+    }
+
+    private boolean getFailUnstable() {
+        return this.publisher.getFailUnstable();
+    }
+
+    private boolean getAutoUpdateHealth() {
+        return this.publisher.getAutoUpdateHealth();
+    }
+
+    private boolean getAutoUpdateStability() {
+        return this.publisher.getAutoUpdateStability();
+    }
+
+}

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -4,6 +4,9 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Result;
@@ -50,7 +53,7 @@ import org.kohsuke.stapler.StaplerRequest;
  *
  * @author Stephen Connolly
  */
-public class CoberturaPublisher extends Recorder {
+public class CoberturaPublisher extends Recorder implements MatrixAggregatable {
 
     private final String coberturaReportFile;
 
@@ -316,6 +319,13 @@ public class CoberturaPublisher extends Recorder {
     /*package*/
     static File[] getCoberturaReports(AbstractBuild<?, ?> build) {
         return build.getRootDir().listFiles(COBERTURA_FILENAME_FILTER);
+    }
+
+    public MatrixAggregator createAggregator(
+            final MatrixBuild build,
+            final Launcher launcher,
+            final BuildListener listener) {
+        return new CoberturaMatrixAggregator(build, launcher, listener, this);
     }
 
     /**


### PR DESCRIPTION
by copying and parsing `coverage.xml` files from each [`MatrixRun`](http://javadoc.jenkins-ci.org/hudson/matrix/MatrixRun.html).

This is my second attempt at addressing
https://issues.jenkins-ci.org/browse/JENKINS-20706

This works by creating a [`MatrixAggregator`](http://javadoc.jenkins-ci.org/hudson/matrix/MatrixAggregator.html) that on [`endRun`](http://javadoc.jenkins-ci.org/hudson/matrix/MatrixAggregator.html#endRun%28hudson.matrix.MatrixRun%29), copies the `coverage.xml` from each [`MatrixRun`](http://javadoc.jenkins-ci.org/hudson/matrix/MatrixRun.html) into the root build's directory. Then in [`endBuild`](http://javadoc.jenkins-ci.org/hudson/matrix/MatrixAggregator.html#endBuild%28%29), those files are parsed and aggregated.

The advantage of this approach is that it seems to aggregate the coverage in a nice way -- i.e.: if my MatrixBuild does a MatrixRun for Python versions 2.6, 2.7, and 3.3 and each of those has lines that are not covered but all of the lines are covered by at least one MatrixRun, then the coverage for the overall build will be reported as 100%.

Refs:
- https://issues.jenkins-ci.org/browse/JENKINS-20706
- https://github.com/jenkinsci/cobertura-plugin/pull/26 (this PR)
- https://github.com/jenkinsci/cobertura-plugin/pull/22 (older PR)
- https://groups.google.com/forum/#!topic/jenkinsci-dev/yoamyzbqVro

Cc: @ssogabe, @kinow, @emanuelez, @kohsuke 

test
