### PR TITLE
[JENKINS-13489] Fix highlight for partially covered branches.

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -50,12 +50,7 @@ table.source tr.coverPart {
 }
 
 table.source tr.coverPart td.hits, table.source tr.coverNone td.hits {
-    background-color: #fdd;
     font-weight: bold;
-}
-
-table.source tr.coverPart td.code {
-    background-color: #fdd;
 }
 
 table.source tr.coverNone {


### PR DESCRIPTION
This fixes JENKINS-13489 with a slightly different approach then the patch in the ticket, making the CSS a bit less redundant.

PS: On some displays, #ffd is quite hard to differenciate from white, wouldn't something like #ffa work better?
