### PR TITLE
[JENKINS-26823] Prevent concurrent builds blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 temp
 work
 *.iml
+.idea/

--- a/src/main/java/hudson/plugins/cobertura/BuildUtils.java
+++ b/src/main/java/hudson/plugins/cobertura/BuildUtils.java
@@ -1,0 +1,17 @@
+package hudson.plugins.cobertura;
+
+import hudson.model.AbstractBuild;
+
+public class BuildUtils {
+	public static AbstractBuild<?, ?> getPreviousNotFailedCompletedBuild(AbstractBuild<?, ?> b) {
+		while (true) {
+			b = b.getPreviousNotFailedBuild();
+			if (b == null) {
+				return null;
+			}
+			if (!b.isBuilding()) {
+				return b;
+			}
+		}
+	}
+}

--- a/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
@@ -159,7 +159,7 @@ public class CoberturaBuildAction implements HealthReportingAction, StaplerProxy
     static CoberturaBuildAction getPreviousResult(AbstractBuild<?, ?> start) {
         AbstractBuild<?, ?> b = start;
         while (true) {
-            b = b.getPreviousNotFailedBuild();
+            b = BuildUtils.getPreviousNotFailedCompletedBuild(b);
             if (b == null) {
                 return null;
             }

--- a/src/main/java/hudson/plugins/cobertura/CoberturaProjectAction.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaProjectAction.java
@@ -61,7 +61,7 @@ public class CoberturaProjectAction extends Actionable implements ProminentProje
      * @return Value for property 'lastResult'.
      */
     public CoberturaBuildAction getLastResult() {
-        for (AbstractBuild<?, ?> b = getLastBuildToBeConsidered(); b != null; b = b.getPreviousNotFailedBuild()) {
+        for (AbstractBuild<?, ?> b = getLastBuildToBeConsidered(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
             if (b.getResult() == Result.FAILURE || (b.getResult() != Result.SUCCESS && onlyStable))
                 continue;
             CoberturaBuildAction r = b.getAction(CoberturaBuildAction.class);
@@ -79,7 +79,7 @@ public class CoberturaProjectAction extends Actionable implements ProminentProje
      * @return Value for property 'lastResult'.
      */
     public Integer getLastResultBuild() {
-        for (AbstractBuild<?, ?> b = getLastBuildToBeConsidered(); b != null; b = b.getPreviousNotFailedBuild()) {
+        for (AbstractBuild<?, ?> b = getLastBuildToBeConsidered(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
             if (b.getResult() == Result.FAILURE || (b.getResult() != Result.SUCCESS && onlyStable))
                 continue;
             CoberturaBuildAction r = b.getAction(CoberturaBuildAction.class);

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -500,7 +500,7 @@ public class CoberturaPublisher extends Recorder {
      * {@inheritDoc}
      */
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     /**

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.Run;
+import hudson.plugins.cobertura.BuildUtils;
 import hudson.plugins.cobertura.Chartable;
 import hudson.plugins.cobertura.CoberturaBuildAction;
 import hudson.plugins.cobertura.CoverageChart;
@@ -435,13 +436,13 @@ public class CoverageResult implements Serializable, Chartable {
             if (owner == null) {
                 return null;
             }
-            Run<?, ?> prevBuild = owner.getPreviousNotFailedBuild();
+            AbstractBuild<?, ?> prevBuild = BuildUtils.getPreviousNotFailedCompletedBuild(owner);
             if (prevBuild == null) {
                 return null;
             }
             CoberturaBuildAction action = null;
             while ((prevBuild != null) && (null == (action = prevBuild.getAction(CoberturaBuildAction.class)))) {
-                prevBuild = prevBuild.getPreviousNotFailedBuild();
+                prevBuild = BuildUtils.getPreviousNotFailedCompletedBuild(prevBuild);
             }
             if (action == null) {
                 return null;

--- a/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/config.properties
@@ -6,7 +6,10 @@ xml.report.pattern.description=\
  workspace root.  Note that the module root is SCM-specific, and may \
  not be the same as the workspace root. \
  <br/> \
- Cobertura must be configured to generate XML reports for this plugin to function.
+ Cobertura must be configured to generate XML reports for this plugin to function. \
+ <br/> \
+ NOTE: If concurrent builds are enabled for this job, and a later build finishes \
+ before an earlier build, the later build will reduce or skip trend analysis/charting.
 only.stable.builds.description=Include only stable builds, i.e. exclude unstable and failed ones.
 unhealthy.fail.builds.description=Unhealthy projects will be failed.
 unstable.fail.builds.description=Unstable projects will be failed.

--- a/src/test/java/hudson/plugins/cobertura/CoverageResultBuilder.java
+++ b/src/test/java/hudson/plugins/cobertura/CoverageResultBuilder.java
@@ -63,6 +63,7 @@ public class CoverageResultBuilder
 			EasyMock.expect( build.getAction( CoberturaBuildAction.class ) ).andReturn( action ).anyTimes();
 			EasyMock.expect( build.getDisplayName() ).andReturn( "#" + String.valueOf( c ) ).anyTimes();
 			EasyMock.expect( build.getPreviousNotFailedBuild() ).andReturn( prevBuild ).anyTimes();
+			EasyMock.expect( build.isBuilding() ).andReturn( false ).anyTimes();
 
 			result.setOwner( build );
 


### PR DESCRIPTION
If a previous build is still running, it will be ignored (along with
any earlier builds).