### PR TITLE
[FIXED JENKINS-13889] Not able to find source code from subdirectories

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -397,6 +397,17 @@ public class CoberturaPublisher extends Recorder {
             result.setOwner(build);
             final FilePath paintedSourcesPath = new FilePath(new File(build.getProject().getRootDir(), "cobertura"));
             paintedSourcesPath.mkdirs();
+
+            if (sourcePaths.contains(".")) {
+                sourcePaths.remove(".");
+                for (FilePath f : reports) {
+                    FilePath p = f.getParent();
+                    if (p != null && p.isDirectory()) {
+                        sourcePaths.add(p.getRemote());
+                    }
+                }
+            }
+
             SourceCodePainter painter = new SourceCodePainter(paintedSourcesPath, sourcePaths,
                     result.getPaintedSources(), listener, getSourceEncoding());
 


### PR DESCRIPTION
Adding locations of "coverage.xml" files to sourcePaths in case of current directory (".") specified as root directory.

FIXES https://issues.jenkins-ci.org/browse/JENKINS-13889