### PR TITLE
Add support for matrix builds

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaCoverageParser.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaCoverageParser.java
@@ -195,8 +195,8 @@ class CoberturaXmlHandler extends DefaultHandler {
         } else if ("line".equals(qName)) {
             String hitsString = attributes.getValue("hits");
             String lineNumber = attributes.getValue("number");
-            int denominator = 0;
-            int numerator = 0;
+            double denominator = 0;
+            double numerator = 0;
             if (Boolean.parseBoolean(attributes.getValue("branch"))) {
                 final String conditionCoverage = attributes.getValue("condition-coverage");
                 if (conditionCoverage != null) {
@@ -212,9 +212,9 @@ class CoberturaXmlHandler extends DefaultHandler {
                         final String numeratorStr = matcher.group(2);
                         final String denominatorStr = matcher.group(3);
                         try {
-                            numerator = Integer.parseInt(numeratorStr);
-                            denominator = Integer.parseInt(denominatorStr);
-                            rootCoverage.updateMetric(CoverageMetric.CONDITIONAL, Ratio.create(numerator, denominator));
+                            numerator = Double.parseDouble(numeratorStr);
+                            denominator = Double.parseDouble(denominatorStr);
+                            rootCoverage.updateMetric(CoverageMetric.CONDITIONAL, Ratio.create((int)numerator, (int)denominator));
                         } catch (NumberFormatException e) {
                             // ignore
                         }
@@ -222,12 +222,12 @@ class CoberturaXmlHandler extends DefaultHandler {
                 }
             }
             try {
-                int hits = Integer.parseInt(hitsString);
-                int number = Integer.parseInt(lineNumber);
+                double hits = Integer.parseInt(hitsString);
+                double number = Integer.parseInt(lineNumber);
                 if (denominator == 0) {
-                    rootCoverage.paint(number, hits);
+                    rootCoverage.paint((int)number, (int)hits);
                 } else {
-                    rootCoverage.paint(number, hits, numerator, denominator);
+                    rootCoverage.paint((int)number, (int)hits, (int)numerator, (int)denominator);
                 }
                 rootCoverage.updateMetric(CoverageMetric.LINE, Ratio.create((hits == 0) ? 0 : 1, 1));
             } catch (NumberFormatException e) {

--- a/src/main/java/hudson/plugins/cobertura/CoberturaMatrixAggregator.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaMatrixAggregator.java
@@ -1,0 +1,128 @@
+package hudson.plugins.cobertura;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import static hudson.plugins.cobertura.CoberturaPublisher.getCoberturaReports;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import hudson.plugins.cobertura.targets.CoverageTarget;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CoberturaMatrixAggregator extends MatrixAggregator {
+
+    private final CoberturaPublisher publisher;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param build the MatrixBuild to aggregate coverage for.
+     * @param launcher the launcher.
+     * @param listener the listener.
+     * @param publisher the CoberturaPublisher
+     */
+    public CoberturaMatrixAggregator(
+            MatrixBuild build,
+            Launcher launcher,
+            BuildListener listener,
+            CoberturaPublisher publisher) {
+        super(build, launcher, listener);
+        this.publisher = publisher;
+    }
+
+    @Override
+    public boolean endRun(MatrixRun run) {
+    	// copies the coverage.xml from each MatrixRun into the root build's directory
+    	
+        FilePath rootBuildDir = new FilePath(build.getRootBuild().getRootDir());
+
+        for (File coberturaXmlReport : getCoberturaReports(run)) {
+            FilePath report = new FilePath(coberturaXmlReport.getAbsoluteFile());
+            final FilePath rootTargetPath = new FilePath(
+                rootBuildDir,
+                "coverage_" + run.getWorkspace().getBaseName() + ".xml"
+            );
+
+            try {
+                report.copyTo(rootTargetPath);
+            } catch (IOException ex) {
+                Logger.getLogger(CoberturaMatrixAggregator.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (InterruptedException ex) {
+                Logger.getLogger(CoberturaMatrixAggregator.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean endBuild() {
+    	// files are parsed and aggregated
+    	
+        CoverageResult result = null;
+
+        for (File report : getCoberturaReports(build)) {
+            try {
+                result = CoberturaCoverageParser.parse(report, result);
+            } catch (IOException e) {
+                Util.displayIOException(e, listener);
+                e.printStackTrace(
+                    listener.fatalError("Unable to parse " + report)
+                );
+                build.setResult(Result.FAILURE);
+            }
+        }
+
+        if (result != null) {
+            result.setOwner(build);
+            build.addAction(
+                CoberturaBuildAction.load(
+                    build,
+                    result,
+                    this.getHealthyTarget(), this.getUnhealthyTarget(),
+                    this.getOnlyStable(),
+                    this.getFailUnhealthy(), this.getFailUnstable(),
+                    this.getAutoUpdateHealth(), this.getAutoUpdateStability()
+                )
+            );
+        }
+
+        return true;
+    }
+
+    private CoverageTarget getHealthyTarget() {
+        return this.publisher.getHealthyTarget();
+    }
+
+    private CoverageTarget getUnhealthyTarget() {
+        return this.publisher.getUnhealthyTarget();
+    }
+
+    private boolean getOnlyStable() {
+        return this.publisher.getOnlyStable();
+    }
+
+    private boolean getFailUnhealthy() {
+        return this.publisher.getFailUnhealthy();
+    }
+
+    private boolean getFailUnstable() {
+        return this.publisher.getFailUnstable();
+    }
+
+    private boolean getAutoUpdateHealth() {
+        return this.publisher.getAutoUpdateHealth();
+    }
+
+    private boolean getAutoUpdateStability() {
+        return this.publisher.getAutoUpdateStability();
+    }
+
+}


### PR DESCRIPTION
- Change line count variables to doubles to avoid overflow. Currently if
  the line count increments over the integer max it goes to 0.
- Add support for matrix jobs. Coverage displays by individual labels
  and is aggregated for the main page.
- Add support for environment variables to be passed in.

Matrix integration code provided by:
https://github.com/jenkinsci/cobertura-plugin/pull/26

Fixes:
https://github.com/jenkinsci/cobertura-plugin/issues/37
https://issues.jenkins-ci.org/browse/JENKINS-30647
