### PR TITLE
JENKINS-30700 / #50 Jenkins pipeline support

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -694,9 +694,10 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
          */
         @Override
         public CoberturaPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-        	if (req == null) {
-        		return null;
-        	}
+            // Null check because findbugs insists, despite the API guaranteeing this is never null.
+            if (req == null) {
+                throw new FormException("req cannot be null", "");
+            }
             CoberturaPublisher instance = req.bindJSON(CoberturaPublisher.class, formData);
             ConvertUtils.register(CoberturaPublisherTarget.CONVERTER, CoverageMetric.class);
             List<CoberturaPublisherTarget> targets = req

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -385,6 +385,13 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         FilePath[] reports = null;
         try {
             reports = workspace.act(new ParseReportCallable(coberturaReportFile));
+
+            // if the build has failed, then there's not
+            // much point in reporting an error
+            if (buildResult != null && buildResult.isWorseOrEqualTo(Result.FAILURE) && reports.length == 0) {
+                return;
+            }
+
         } catch (IOException e) {
             Util.displayIOException(e, listener);
             e.printStackTrace(listener.fatalError("Unable to find coverage results"));

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageTarget.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageTarget.java
@@ -106,13 +106,12 @@ public class CoverageTarget implements Serializable {
     }
 
     public Map<CoverageMetric, Integer> getRangeScores(CoverageTarget min, Map<CoverageMetric, Ratio> results) {
-        Integer j;
         Map<CoverageMetric, Integer> result = new EnumMap<CoverageMetric, Integer>(CoverageMetric.class);
         for (Map.Entry<CoverageMetric, Integer> target : this.targets.entrySet()) {
             Ratio observed = results.get(target.getKey());
             if (observed != null) {
-                j = CoverageTarget.calcRangeScore(target.getValue() / 100000, min.targets.get(target.getKey()), observed.getPercentage());
-                result.put(target.getKey(), j);
+                int j = CoverageTarget.calcRangeScore(target.getValue() / 100000, min.targets.get(target.getKey()), observed.getPercentage());
+                result.put(target.getKey(), Integer.valueOf(j));
             }
         }
         return result;


### PR DESCRIPTION
I have created a branch that implements pipeline support, and the very basic thing worked in my own deployment (ran a single build with the CoberturaPublisher step). It ran with the following entry in my Jenkinsfile:

```
step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', failNoReports: false, failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])
```

Since I'm not completely familiar with the Jenkins API, there are probably bugs and regressions, but I did get a report and a graph at the top of my multibranch build after running a job on a separate build slave. More eyes to look at this are appreciated. Here's what I'm unsure about:
- I haven't tried seeing if it kept backwards compatibility with non-pipeline jobs. (Probably not)
- Since I'm not doing Java builds, the MavenCoberturaPublisher is untested, and I probably broke it.
- I copied the zoomCoverageChart and maxNumberOfBuilds into the CoberturaBuildAction to allow those values to be accessed without having a CoberturaPublisher instance. I think this is the right approach, but someone more familiar with the API would know better.
- Even if backwards compatibility were maintained, with ZoomCoverageChart and MaxNumberOfBuilds now, you may have to trigger a new build to see an updated graph, whereas previously you might have been able to modify the graph merely by changing the job definition, without re-running the job.
- In CoberturaPublisher.perform(), I'm not sure if my replacing moduleRoot with workspace is the right thing.
- I'm unsure if FilePath.FileCallable should have been replaced with something other than SlaveToMasterFileCallable
- My project wouldn't build with that maven-plugin dependency in pom.xml that excluded a library that is claimed to conflict with easymock dependencies, and built and tested fine without it. Is it really unneeded now, or did I break something?
- Are these the right Jenkins and workflow versions in pom.xml?
- I _gulp_ didn't add any unit tests for the new functionality, but the old ones passed as currently modified.
- I haven't tried seeing what happens if you specify the cobertura step multiple times in the same Jenkinsfile. Likely, multiple coverage reports in a single pipeline will each need to get a unique label added to it so that the coverage changes can be tracked separately between different builds.
- I did not attempt any backwards compatibility when using the new plugin but viewing old builds that had their state saved from older versions of cobertura-plugin. Perhaps that is broken.

Please review and suggest changes.
