### PR TITLE
JENKINS-17800 remove deprecated use of ChartUtil.generateGraph

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
@@ -9,8 +9,8 @@ import hudson.model.Run;
 import hudson.plugins.cobertura.targets.CoverageMetric;
 import hudson.plugins.cobertura.targets.CoverageTarget;
 import hudson.plugins.cobertura.targets.CoverageResult;
-import hudson.util.ChartUtil;
 import hudson.util.DescribableList;
+import hudson.util.Graph;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 
@@ -265,19 +265,12 @@ public class CoberturaBuildAction implements HealthReportingAction, StaplerProxy
      * @throws IOException forwarded from StaplerResponse.sendRedirect2
      */
     public void doGraph(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        if (ChartUtil.awtProblemCause != null) {
-            // not available. send out error message
-            rsp.sendRedirect2(req.getContextPath() + "/images/headless.png");
-            return;
-        }
-
-        Calendar t = owner.getTimestamp();
-
-        if (req.checkIfModified(t, rsp)) {
-            return; // up to date
-        }
-        JFreeChart chart = new CoverageChart(this).createChart();
-        ChartUtil.generateGraph(req, rsp, chart, 500, 200);
+        new Graph(owner.getTimestamp(), 500, 200) {
+            @Override
+            protected JFreeChart createGraph() {
+                return new CoverageChart(CoberturaBuildAction.this).createChart();
+            }
+        }.doPng(req, rsp);
     }
 
     public boolean getZoomCoverageChart() {

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -8,7 +8,7 @@ import hudson.plugins.cobertura.Chartable;
 import hudson.plugins.cobertura.CoberturaBuildAction;
 import hudson.plugins.cobertura.CoverageChart;
 import hudson.plugins.cobertura.Ratio;
-import hudson.util.ChartUtil;
+import hudson.util.Graph;
 import hudson.util.TextFile;
 
 import java.io.File;
@@ -469,20 +469,12 @@ public class CoverageResult implements Serializable, Chartable {
      * @throws IOException from StaplerResponse.sendRedirect2
      */
     public void doGraph(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        if (ChartUtil.awtProblemCause != null) {
-            // not available. send out error message
-            rsp.sendRedirect2(req.getContextPath() + "/images/headless.png");
-            return;
-        }
-
-        Run<?, ?> build = getOwner();
-        Calendar t = build.getTimestamp();
-
-        if (req.checkIfModified(t, rsp)) {
-            return; // up to date
-        }
-        JFreeChart chart = new CoverageChart(this).createChart();
-        ChartUtil.generateGraph(req, rsp, chart, 500, 200);
+        new Graph(owner.getTimestamp(), 500, 200) {
+            @Override
+            protected JFreeChart createGraph() {
+                return new CoverageChart(CoverageResult.this).createChart();
+            }
+        }.doPng(req, rsp);
     }
 
     /**


### PR DESCRIPTION
This PR resolves JENKINS-17800 by removing use of the deprecated ChartUtil class, instead using the hudson.utils.Graph class directly, substituting with code similar to the deprecation replacement at https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/ChartUtil.java#L143

Since https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/Graph.java#L117 contains the timestamp check already, we pass the timestamp directly to the Graph constructor.

https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/Graph.java#L157 shows that the new Graph class already contains an equivalent check to what https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/util/ChartUtil.java#L260 is doing to populate awtProblemCause, so that check is dropped too.