### PR TITLE
change the link of Cobertura

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/cobertura-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/cobertura-plugin/)
 
 This plugin allows you to capture code coverage report from
-[Cobertura](http://cobertura.sourceforge.net/).
+[Cobertura](https://github.com/cobertura/cobertura/).
 Jenkins will generate the trend report of coverage.
 The Cobertura plugin can be [downloaded
 here](http://updates.jenkins-ci.org/download/plugins/cobertura/).


### PR DESCRIPTION
change the link of Cobertura from sourceforge.net to github.com