### PR TITLE
Expose coverage targets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>cobertura</artifactId>
   <packaging>hpi</packaging>
-  <version>1.10</version>
+  <version>1.11-SNAPSHOT</version>
   <name>Jenkins Cobertura Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin</url>
 
@@ -24,7 +24,7 @@
    <connection>scm:git:git://github.com/jenkinsci/cobertura-plugin.git</connection>
    <developerConnection>scm:git:git@github.com:jenkinsci/cobertura-plugin.git</developerConnection>
    <url>https://github.com/jenkinsci/cobertura-plugin</url>
-    <tag>cobertura-1.10</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.io.IOException;
+import java.lang.Float;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -73,6 +74,18 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
     private int maxNumberOfBuilds = 0;
 
     private boolean failNoReports = true;
+
+    private String lineCoverageTargets = null;
+
+    private String packageCoverageTargets = null;
+
+    private String fileCoverageTargets = null;
+
+    private String classCoverageTargets = null;
+
+    private String methodCoverageTargets = null;
+
+    private String conditionalCoverageTargets = null;
 
     private CoverageTarget healthyTarget = new CoverageTarget();
 
@@ -304,6 +317,120 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
     }
 
     /**
+     * Setter for property 'lineCoverageTargets'.
+     *
+     * @param targets Value to set for property 'lineCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setLineCoverageTargets(String targets) throws AbortException {
+      lineCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'lineCoverageTargets'.
+     *
+     * @return Value for property 'lineCoverageTargets'.
+     */
+    public String getLineCoverageTargets() {
+      return lineCoverageTargets;
+    }
+
+    /**
+     * Setter for property 'packageCoverageTargets'.
+     *
+     * @param targets Value to set for property 'packageCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setPackageCoverageTargets(String targets) {
+      packageCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'packageCoverageTargets'.
+     *
+     * @return Value for property 'packageCoverageTargets'.
+     */
+    public String getPackageCoverageTargets() {
+      return packageCoverageTargets;
+    }
+
+    /**
+     * Setter for property 'fileCoverageTargets'.
+     *
+     * @param targets Value to set for property 'fileCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setFileCoverageTargets(String targets) {
+      fileCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'fileCoverageTargets'.
+     *
+     * @return Value for property 'fileCoverageTargets'.
+     */
+    public String getFileCoverageTargets() {
+      return fileCoverageTargets;
+    }
+
+    /**
+     * Setter for property 'classCoverageTargets'.
+     *
+     * @param targets Value to set for property 'classCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setClassCoverageTargets(String targets) {
+      classCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'classCoverageTargets'.
+     *
+     * @return Value for property 'classCoverageTargets'.
+     */
+    public String getClassCoverageTargets() {
+      return classCoverageTargets;
+    }
+
+    /**
+     * Setter for property 'methodCoverageTargets'.
+     *
+     * @param targets Value to set for property 'methodCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setMethodCoverageTargets(String targets) {
+      methodCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'methodCoverageTargets'.
+     *
+     * @return Value for property 'methodCoverageTargets'.
+     */
+    public String getMethodCoverageTargets() {
+      return methodCoverageTargets;
+    }
+
+    /**
+     * Setter for property 'conditionalCoverageTargets'.
+     *
+     * @param targets Value to set for property 'conditionalCoverageTargets'.
+     */
+    @DataBoundSetter
+    public void setConditionalCoverageTargets(String targets) {
+      conditionalCoverageTargets = targets;
+    }
+
+    /**
+     * Getter for property 'conditionalCoverageTargets'.
+     *
+     * @return Value for property 'conditionalCoverageTargets'.
+     */
+    public String getConditionalCoverageTargets() {
+      return conditionalCoverageTargets;
+    }
+
+    /**
      * Getter for property 'healthyTarget'.
      *
      * @return Value for property 'healthyTarget'.
@@ -371,6 +498,9 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
     @Override
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, final TaskListener listener)
             throws InterruptedException, IOException {
+
+        setAllCoverageTargets();
+
         Result threshold = onlyStable ? Result.SUCCESS : Result.UNSTABLE;
         Result buildResult = build.getResult();
         if (buildResult != null && buildResult.isWorseThan(threshold)) {
@@ -507,6 +637,93 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
             throw new AbortException("No coverage results were successfully parsed.  Did you generate "
                     + "the XML report(s) for Cobertura?");
         }
+    }
+
+    /**
+     * Parses any coverage strings provided to the plugin and sets the
+     * coverage targets.
+     * 
+     * @throws AbortException
+     */
+    private void setAllCoverageTargets() throws AbortException {
+      if (lineCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.LINE, lineCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for lineCoverageTargets");
+        }
+      }
+
+      if (packageCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.PACKAGES, packageCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for packageCoverageTargets");
+        }
+      }
+
+      if (fileCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.FILES, fileCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for fileCoverageTargets");
+        }
+      }
+
+      if (classCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.CLASSES, classCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for classCoverageTargets");
+        }
+      }
+
+      if (methodCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.METHOD, methodCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for methodCoverageTargets");
+        }
+      }
+
+      if (conditionalCoverageTargets != null) {
+        try {
+          setCoverageTargets(CoverageMetric.CONDITIONAL, conditionalCoverageTargets);
+        } catch (NumberFormatException e) {
+          throw new AbortException("Invalid value for conditionalCoverageTargets");
+        }
+      }      
+    }
+
+    /**
+     * Parses a coverage string into the parts. A coverage string is of the 
+     * form <health y%>,<unhealthy %>,<unstable %>
+     * @param targets The coverage string
+     * @return an array[3] of floats with the coverage thresholds
+     */
+    private float[] parseCoverageTargets(String targets) {
+      String[] targetValues = targets.split(",");
+      float[] result = new float[3];
+
+      for (int i = 0; i < targetValues.length && i < result.length; i++) {
+        result[i] = Float.valueOf(targetValues[i]);
+      }
+      return result;
+    }
+
+
+    /**
+     * Sets the coverage for one metric from a coverage string
+     * @param metric The metric to set
+     * @param targets A coverage string containing healthy %, unhealthy %,
+     * unstable %
+     */
+    private void setCoverageTargets(CoverageMetric metric, String targets) {
+      float[] targetValues = parseCoverageTargets(targets);
+
+      healthyTarget.setTarget(metric, Math.round(targetValues[0] * 100000));
+      unhealthyTarget.setTarget(metric, Math.round(targetValues[1] * 100000));
+      failingTarget.setTarget(metric, Math.round(targetValues[2] * 100000));
     }
 
     /**

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
@@ -15,12 +15,12 @@ import hudson.FilePath;
 import jenkins.model.Jenkins;
 
 public class CoberturaPublisherPipelineTest {
-    
+
     /**
-    * Helper class to build a script with a CoverturaPublisher step
-    */
+     * Helper class to build a script with a CoberturaPublisher step
+     */
     protected class ScriptBuilder {
-        
+
         private String result = "SUCCESS";
         private Boolean onlyStable = true;
         private Boolean failUnhealthy = true;
@@ -33,95 +33,85 @@ public class CoberturaPublisherPipelineTest {
         private String methodCoverage = null;
         
         /**
-        * Sets the build result for the script
-        * 
-        * @param result
-        *            The value for result
-        * @return ScriptBuilder instance
-        */
+         * Sets the build result for the script
+         * @param result The value for result
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setBuildResult(String result) {
             this.result = result;
             return this;
         }
-        
+
         /**
-        * Sets the value for the onlyStable property
-        * 
-        * @param onlyStable
-        *            The value for onlyStable
-        * @return ScriptBuilder instance
-        */
+         * Sets the value for the onlyStable property
+         * @param onlyStable The value for onlyStable
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setOnlyStable(Boolean onlyStable) {
             this.onlyStable = onlyStable;
             return this;
         }
-        
+
         /**
-        * Sets the value for the failUnhealthy property
-        * 
-        * @param onlyStable
-        *            The value for failUnhealthy
-        * @return ScriptBuilder instance
-        */
+         * Sets the value for the failUnhealthy property
+         * 
+         * @param onlyStable The value for failUnhealthy
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setFailUnhealthy(Boolean failUnhealthy) {
             this.failUnhealthy = failUnhealthy;
             return this;
         }
         
         /**
-        * Sets the value for the failUnstable property
-        * 
-        * @param onlyStable
-        *            The value for failUnstable
-        * @return ScriptBuilder instance
-        */
+         * Sets the value for the failUnstable property
+         * 
+         * @param onlyStable The value for failUnstable
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setFailUnstable(Boolean failUnstable) {
             this.failUnstable = failUnstable;
             return this;
         }
         
         /**
-        * Sets the targets for line coverage
-        * 
-        * @param lineCoverage
-        *            Targets for line coverage
-        * @return ScriptBuilder instance
-        */
+         * Sets the targets for line coverage
+         * 
+         * @param lineCoverage Targets for line coverage
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setLineCoverage(String lineCoverage) {
             this.lineCoverage = lineCoverage;
             return this;
         }
         
         /**
-        * Sets the targets for branch coverage
-        * 
-        * @param lineCoverage
-        *            Targets for line coverage
-        * @return ScriptBuilder instance
-        */
+         * Sets the targets for branch coverage
+         * 
+         * @param lineCoverage Targets for line coverage
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setBranchCoverage(String branchCoverage) {
             this.branchCoverage = branchCoverage;
             return this;
         }
         
         /**
-        * Sets the targets for file coverage
-        * 
-        * @param fileCoverage
-        *            Targets for file coverage
-        * @return ScriptBuilder instance
-        */
+         * Sets the targets for file coverage
+         * 
+         * @param fileCoverage Targets for file coverage
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setFileCoverage(String fileCoverage) {
             this.fileCoverage = fileCoverage;
             return this;
         }		
         
         /**
-        * Sets the targets for package coverage
-        * 
-        * @param packageCoverage
-        *            Targets for package coverage
-        * @return ScriptBuilder instance
+         * Sets the targets for package coverage
+         * 
+         * @param packageCoverage Targets for package coverage
+         * @return ScriptBuilder instance
         */
         ScriptBuilder setPackageCoverage(String packageCoverage) {
             this.packageCoverage = packageCoverage;
@@ -129,24 +119,22 @@ public class CoberturaPublisherPipelineTest {
         }				
         
         /**
-        * Sets the targets for class coverage
-        * 
-        * @param classCoverage
-        *            Targets for class coverage
-        * @return ScriptBuilder instance
-        */
+         * Sets the targets for class coverage
+         * 
+         * @param classCoverage Targets for class coverage
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setClassCoverage(String classCoverage) {
             this.classCoverage = classCoverage;
             return this;
         }				
         
         /**
-        * Sets the targets for method coverage
-        * 
-        * @param methodCoverage
-        *            Targets for method coverage
-        * @return ScriptBuilder instance
-        */
+         * Sets the targets for method coverage
+         * 
+         * @param methodCoverage Targets for method coverage
+         * @return ScriptBuilder instance
+         */
         ScriptBuilder setMethodCoverage(String methodCoverage) {
             this.methodCoverage = methodCoverage;
             return this;
@@ -154,10 +142,9 @@ public class CoberturaPublisherPipelineTest {
         
         
         /**
-        * Gets the script as a string
-        * 
-        * @return The script
-        */
+         * Gets the script as a string
+         * @return The script
+         */
         String getScript() {
             StringBuilder script = new StringBuilder();
             script.append("node {\n");
@@ -190,121 +177,117 @@ public class CoberturaPublisherPipelineTest {
             return script.toString();
         }
     }
-    
+
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-    
+
     /**
-    * Tests that a run with a report file publishes
-    */
+     * Tests that a run with a report file publishes
+     */
     @Test
-    public void testReportFile() throws Exception {
+    public void testReportFile()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
+
         project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
-        
+
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
-        
+
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
     }
-    
+
     /**
-    * Tests no report is published if coverage file isn't found
-    */
+     * Tests no report is published if coverage file isn't found
+     */
     @Test
-    public void testNoReportFile() throws Exception {
+    public void testNoReportFile()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
+
         project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
-        
+
         ensureWorkspaceExists(project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
-        
+
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogNotContains("Cobertura coverage report found.", run);
     }
-    
+
     /**
-    * Tests report is published for unstable build if onlyStable = false
-    */
+     * Tests report is published for unstable build if onlyStable = false
+     */
     @Test
-    public void testUnstableOnlyStableFalse() throws Exception {
+    public void testUnstableOnlyStableFalse()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
-        project.setDefinition(
-        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
-        
+
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
+
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
-        
+
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
     }
-    
+
     /**
-    * Tests report is not published for unstable build if onlyStable = true
-    */
+     * Tests report is not published for unstable build if onlyStable = true
+     */
     @Test
-    public void testUnstableOnlyStableTrue() throws Exception {
+    public void testUnstableOnlyStableTrue()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
-        project.setDefinition(
-        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
-        
+
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
+
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
-        
+
         jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
     }
-    
+
     /**
-    * Tests no report is published for failed build if onlyStable = true
-    */
+     * Tests no report is published for failed build if onlyStable = true
+     */
     @Test
-    public void testFailedOnlyStableTrue() throws Exception {
+    public void testFailedOnlyStableTrue()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
-        project.setDefinition(
-        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
-        
+
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
+
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
-        
+
         jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
     }
-    
+
     /**
-    * Tests report is not published for failed build if onlyStable = true
-    */
+     * Tests report is not published for failed build if onlyStable = true
+     */
     @Test
-    public void testFailedOnlyStableFalse() throws Exception {
+    public void testFailedOnlyStableFalse()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-        
-        project.setDefinition(
-        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
-        
+
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
+
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-        
+
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
         
@@ -572,38 +555,31 @@ public class CoberturaPublisherPipelineTest {
     }	
     
     /**
-    * Creates workspace directory if needed, and returns it
-    * 
-    * @param job
-    *            The job for the workspace
-    * @return File representing workspace directory
-    */
+     * Creates workspace directory if needed, and returns it
+     * @param job The job for the workspace
+     * @return File representing workspace directory
+     */
     private File ensureWorkspaceExists(WorkflowJob job) {
         FilePath path = jenkinsRule.jenkins.getWorkspaceFor(job);
         File directory = new File(path.getRemote());
         directory.mkdirs();
-        
+
         return directory;
     }
-    
+
     /**
-    * Copies a coverage file from resources to a job's workspace directory
-    * 
-    * @param sourceResourceName
-    *            The name of the resource to copy
-    * @param targetFileName
-    *            The name of the file in the target workspace
-    * @param job
-    *            The job to copy the file to
-    * @throws IOException
-    */
-    private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job)
-    throws IOException {
+     * Copies a coverage file from resources to a job's workspace directory
+     * @param sourceResourceName The name of the resource to copy
+     * @param targetFileName The name of the file in the target workspace
+     * @param job The job to copy the file to
+     * @throws IOException
+     */
+    private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job) throws IOException {
         File directory = ensureWorkspaceExists(job);
-        
+
         File dest = new File(directory, targetFileName);
         File src = new File(getClass().getResource(sourceResourceName).getPath());
-        
+
         FileUtils.copyFile(src, dest);
     };
 }

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
@@ -16,194 +16,594 @@ import jenkins.model.Jenkins;
 
 public class CoberturaPublisherPipelineTest {
 
-    /**
-     * Helper class to build a script with a CoverturaPublisher step
-     */
-    protected class ScriptBuilder {
+	/**
+	 * Helper class to build a script with a CoverturaPublisher step
+	 */
+	protected class ScriptBuilder {
 
-        private String result = "SUCCESS";
-        private Boolean onlyStable = true;
+		private String result = "SUCCESS";
+		private Boolean onlyStable = true;
+		private Boolean failUnhealthy = true;
+		private Boolean failUnstable = true;
+		private String lineCoverage = null;
+		private String branchCoverage = null;
+		private String fileCoverage = null;
+		private String packageCoverage = null;
+		private String classCoverage = null;
+		private String methodCoverage = null;
 
-        /**
-         * Sets the build result for the script
-         * @param result The value for result
-         * @return ScriptBuilder instance
-         */
-        ScriptBuilder setBuildResult(String result) {
-            this.result = result;
-            return this;
-        }
+		/**
+		 * Sets the build result for the script
+		 * 
+		 * @param result
+		 *            The value for result
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setBuildResult(String result) {
+			this.result = result;
+			return this;
+		}
 
-        /**
-         * Sets the build result for the script
-         * @param onlyStable The value for onlyStable
-         * @return ScriptBuilder instance
-         */
-        ScriptBuilder setOnlyStable(Boolean onlyStable) {
-            this.onlyStable = onlyStable;
-            return this;
-        }
+		/**
+		 * Sets the value for the onlyStable property
+		 * 
+		 * @param onlyStable
+		 *            The value for onlyStable
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setOnlyStable(Boolean onlyStable) {
+			this.onlyStable = onlyStable;
+			return this;
+		}
 
-        /**
-         * Gets the script as a string
-         * @return The script
-         */
-        String getScript() {
-            StringBuilder script = new StringBuilder();
-            script.append("node {\n");
-            script.append(String.format("currentBuild.result = '%s'\n", this.result));
-            script.append("step ([$class: 'CoberturaPublisher', ");
-            script.append("coberturaReportFile: '**/coverage.xml', ");
-            script.append(String.format("onlyStable: %s, ", this.onlyStable.toString()));
-            script.append("sourceEncoding: 'ASCII'])\n");
-            script.append("}");
-            return script.toString();
-        }
-    }
+		/**
+		 * Sets the value for the failUnhealthy property
+		 * 
+		 * @param onlyStable
+		 *            The value for failUnhealthy
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setFailUnhealthy(Boolean failUnhealthy) {
+			this.failUnhealthy = failUnhealthy;
+			return this;
+		}
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+		/**
+		 * Sets the value for the failUnstable property
+		 * 
+		 * @param onlyStable
+		 *            The value for failUnstable
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setFailUnstable(Boolean failUnstable) {
+			this.failUnstable = failUnstable;
+			return this;
+		}
 
-    /**
-     * Tests that a run with a report file publishes
-     */
-    @Test
-    public void testReportFile()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		/**
+		 * Sets the targets for line coverage
+		 * 
+		 * @param lineCoverage
+		 *            Targets for line coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setLineCoverage(String lineCoverage) {
+			this.lineCoverage = lineCoverage;
+			return this;
+		}
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
+		/**
+		 * Sets the targets for branch coverage
+		 * 
+		 * @param lineCoverage
+		 *            Targets for line coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setBranchCoverage(String branchCoverage) {
+			this.branchCoverage = branchCoverage;
+			return this;
+		}
 
-        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+		/**
+		 * Sets the targets for file coverage
+		 * 
+		 * @param fileCoverage
+		 *            Targets for file coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setFileCoverage(String fileCoverage) {
+			this.fileCoverage = fileCoverage;
+			return this;
+		}		
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		/**
+		 * Sets the targets for package coverage
+		 * 
+		 * @param packageCoverage
+		 *            Targets for package coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setPackageCoverage(String packageCoverage) {
+			this.packageCoverage = packageCoverage;
+			return this;
+		}				
 
-        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
-    }
+		/**
+		 * Sets the targets for class coverage
+		 * 
+		 * @param classCoverage
+		 *            Targets for class coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setClassCoverage(String classCoverage) {
+			this.classCoverage = classCoverage;
+			return this;
+		}				
 
-    /**
-     * Tests no report is published if coverage file isn't found
-     */
-    @Test
-    public void testNoReportFile()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		/**
+		 * Sets the targets for method coverage
+		 * 
+		 * @param methodCoverage
+		 *            Targets for method coverage
+		 * @return ScriptBuilder instance
+		 */
+		ScriptBuilder setMethodCoverage(String methodCoverage) {
+			this.methodCoverage = methodCoverage;
+			return this;
+		}				
+		
+		
+		/**
+		 * Gets the script as a string
+		 * 
+		 * @return The script
+		 */
+		String getScript() {
+			StringBuilder script = new StringBuilder();
+			script.append("node {\n");
+			script.append(String.format("currentBuild.result = '%s'\n", this.result));
+			script.append("step ([$class: 'CoberturaPublisher', ");
+			script.append("coberturaReportFile: '**/coverage.xml', ");
+			script.append(String.format("onlyStable: %s, ", this.onlyStable.toString()));
+			script.append(String.format("failUnhealthy: %s, ", this.failUnhealthy.toString()));
+			script.append(String.format("failUnstable: %s, ", this.failUnstable.toString()));
+			if (this.lineCoverage != null) {
+				script.append(String.format("lineCoverageTargets: '%s', ", this.lineCoverage));
+			}
+			if (this.branchCoverage != null) {
+				script.append(String.format("conditionalCoverageTargets: '%s', ", this.branchCoverage));
+			}
+			if (this.fileCoverage != null) {
+				script.append(String.format("fileCoverageTargets: '%s', ", this.fileCoverage));				
+			}
+			if (this.packageCoverage != null) {
+				script.append(String.format("packageCoverageTargets: '%s', ", this.packageCoverage));				
+			}
+			if (this.classCoverage != null) {
+				script.append(String.format("classCoverageTargets: '%s', ", this.classCoverage));				
+			}
+			if (this.methodCoverage != null) {
+				script.append(String.format("methodCoverageTargets: '%s', ", this.methodCoverage));				
+			}
+			script.append("sourceEncoding: 'ASCII'])\n");
+			script.append("}");
+			return script.toString();
+		}
+	}
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
+	@Rule
+	public JenkinsRule jenkinsRule = new JenkinsRule();
 
-        ensureWorkspaceExists(project);
+	/**
+	 * Tests that a run with a report file publishes
+	 */
+	@Test
+	public void testReportFile() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
 
-        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogNotContains("Cobertura coverage report found.", run);
-    }
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
-    /**
-     * Tests report is published for unstable build if onlyStable = false
-     */
-    @Test
-    public void testUnstableOnlyStableFalse()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
+	}
 
-        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+	/**
+	 * Tests no report is published if coverage file isn't found
+	 */
+	@Test
+	public void testNoReportFile() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
 
-        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
-    }
+		ensureWorkspaceExists(project);
 
-    /**
-     * Tests report is not published for unstable build if onlyStable = true
-     */
-    @Test
-    public void testUnstableOnlyStableTrue()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogNotContains("Cobertura coverage report found.", run);
+	}
 
-        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+	/**
+	 * Tests report is published for unstable build if onlyStable = false
+	 */
+	@Test
+	public void testUnstableOnlyStableFalse() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		project.setDefinition(
+				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
 
-        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
-    }
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
-    /**
-     * Tests no report is published for failed build if onlyStable = true
-     */
-    @Test
-    public void testFailedOnlyStableTrue()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
+	}
 
-        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+	/**
+	 * Tests report is not published for unstable build if onlyStable = true
+	 */
+	@Test
+	public void testUnstableOnlyStableTrue() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		project.setDefinition(
+				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
 
-        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
-    }
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
-    /**
-     * Tests report is not published for failed build if onlyStable = true
-     */
-    @Test
-    public void testFailedOnlyStableFalse()  throws Exception {
-        Jenkins jenkins = jenkinsRule.jenkins;
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
+		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
+	}
 
-        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+	/**
+	 * Tests no report is published for failed build if onlyStable = true
+	 */
+	@Test
+	public void testFailedOnlyStableTrue() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        WorkflowRun run = project.scheduleBuild2(0).get();
-        jenkinsRule.waitForCompletion(run);
+		project.setDefinition(
+				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
 
-        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not UNSTABLE or better", run);
-    }
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
-    /**
-     * Creates workspace directory if needed, and returns it
-     * @param job The job for the workspace
-     * @return File representing workspace directory
-     */
-    private File ensureWorkspaceExists(WorkflowJob job) {
-        FilePath path = jenkinsRule.jenkins.getWorkspaceFor(job);
-        File directory = new File(path.getRemote());
-        directory.mkdirs();
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
 
-        return directory;
-    }
+		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
+	}
 
-    /**
-     * Copies a coverage file from resources to a job's workspace directory
-     * @param sourceResourceName The name of the resource to copy
-     * @param targetFileName The name of the file in the target workspace
-     * @param job The job to copy the file to
-     * @throws IOException
-     */
-    private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job) throws IOException {
-        File directory = ensureWorkspaceExists(job);
+	/**
+	 * Tests report is not published for failed build if onlyStable = true
+	 */
+	@Test
+	public void testFailedOnlyStableFalse() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        File dest = new File(directory, targetFileName);
-        File src = new File(getClass().getResource(sourceResourceName).getPath());
+		project.setDefinition(
+				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
 
-        FileUtils.copyFile(src, dest);
-    };
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not UNSTABLE or better", run);
+	}
+
+	/**
+	 * Tests failing job when unhealthy due to line coverage
+	 */
+	@Test
+	public void testLineCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,91,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Lines's health is 90.0 and set minimum health is 91.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+	}
+
+	/**
+	 * Tests job unhealthy due to line coverage passes when failUnhealthy is
+	 * false
+	 */
+	@Test
+	public void testLineCoverageUnhealthyNoFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(
+				new ScriptBuilder().setFailUnhealthy(false).setLineCoverage("91,91,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Finished: SUCCESS", run);
+		jenkinsRule.assertLogNotContains("ERROR:", run);
+	}
+
+	/**
+	 * Tests failing job when unstable due to line coverage
+	 */
+	@Test
+	public void testLineCoverageFailUnstable() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,0,91").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
+		jenkinsRule.assertLogContains("Lines's stability is 90.0 and set mininum stability is 91.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+	}
+
+	/**
+	 * Tests job unstable due to line coverage passes when failUnstable is false
+	 */
+	@Test
+	public void testLineCoverageUnstableNoFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(
+				new ScriptBuilder().setFailUnstable(false).setLineCoverage("91,0,91").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Finished: UNSTABLE", run);
+		jenkinsRule.assertLogNotContains("ERROR:", run);
+	}
+
+	/**
+	 * Tests job succeeds when line coverage is exactly target
+	 */
+	@Test
+	public void testLineCoverageSuccess() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,90,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+	}
+
+	/**
+	 * Tests failing job when unhealthy due to branch coverage
+	 */
+	@Test
+	public void testBranchCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,76,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Conditionals's health is 75.0 and set minimum health is 76.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+	}
+
+	/**
+	 * Tests failing job when unstable due to branch coverage
+	 */
+	@Test
+	public void testBranchCoverageFailUnstable() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,0,76").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
+		jenkinsRule.assertLogContains("Conditionals's stability is 75.0 and set mininum stability is 76.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+	}
+
+	/**
+	 * Tests job succeeds when branch coverage is exactly target
+	 */
+	@Test
+	public void testBranchCoverageSuccess() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,75,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+	}
+	
+	/**
+	 * Tests failing job when unhealthy due to file coverage
+	 */
+	@Test
+	public void testFileCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+				.setFileCoverage("80,101,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Files's health is 100.0 and set minimum health is 101.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+		jenkinsRule.assertLogContains("Finished: FAILURE", run);
+	}
+
+	/**
+	 * Tests failing job when unhealthy due to package coverage
+	 */
+	@Test
+	public void testPackageCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+				.setPackageCoverage("80,101,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Packages's health is 100.0 and set minimum health is 101.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+		jenkinsRule.assertLogContains("Finished: FAILURE", run);
+	}	
+
+	/**
+	 * Tests failing job when unhealthy due to class coverage
+	 */
+	@Test
+	public void testClassCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+				.setClassCoverage("80,101,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Classes's health is 100.0 and set minimum health is 101.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+		jenkinsRule.assertLogContains("Finished: FAILURE", run);
+	}		
+	
+	/**
+	 * Tests failing job when unhealthy due to method coverage
+	 */
+	@Test
+	public void testMethodCoverageFail() throws Exception {
+		Jenkins jenkins = jenkinsRule.jenkins;
+		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+
+		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+				.setMethodCoverage("80,101,0").getScript()));
+
+		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+
+		WorkflowRun run = project.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(run);
+
+		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+		jenkinsRule.assertLogContains("Methods's health is 100.0 and set minimum health is 101.0.", run);
+		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+		jenkinsRule.assertLogContains("Finished: FAILURE", run);
+	}	
+	
+	/**
+	 * Creates workspace directory if needed, and returns it
+	 * 
+	 * @param job
+	 *            The job for the workspace
+	 * @return File representing workspace directory
+	 */
+	private File ensureWorkspaceExists(WorkflowJob job) {
+		FilePath path = jenkinsRule.jenkins.getWorkspaceFor(job);
+		File directory = new File(path.getRemote());
+		directory.mkdirs();
+
+		return directory;
+	}
+
+	/**
+	 * Copies a coverage file from resources to a job's workspace directory
+	 * 
+	 * @param sourceResourceName
+	 *            The name of the resource to copy
+	 * @param targetFileName
+	 *            The name of the file in the target workspace
+	 * @param job
+	 *            The job to copy the file to
+	 * @throws IOException
+	 */
+	private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job)
+			throws IOException {
+		File directory = ensureWorkspaceExists(job);
+
+		File dest = new File(directory, targetFileName);
+		File src = new File(getClass().getResource(sourceResourceName).getPath());
+
+		FileUtils.copyFile(src, dest);
+	};
 }

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
@@ -15,595 +15,595 @@ import hudson.FilePath;
 import jenkins.model.Jenkins;
 
 public class CoberturaPublisherPipelineTest {
-
-	/**
-	 * Helper class to build a script with a CoverturaPublisher step
-	 */
-	protected class ScriptBuilder {
-
-		private String result = "SUCCESS";
-		private Boolean onlyStable = true;
-		private Boolean failUnhealthy = true;
-		private Boolean failUnstable = true;
-		private String lineCoverage = null;
-		private String branchCoverage = null;
-		private String fileCoverage = null;
-		private String packageCoverage = null;
-		private String classCoverage = null;
-		private String methodCoverage = null;
-
-		/**
-		 * Sets the build result for the script
-		 * 
-		 * @param result
-		 *            The value for result
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setBuildResult(String result) {
-			this.result = result;
-			return this;
-		}
-
-		/**
-		 * Sets the value for the onlyStable property
-		 * 
-		 * @param onlyStable
-		 *            The value for onlyStable
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setOnlyStable(Boolean onlyStable) {
-			this.onlyStable = onlyStable;
-			return this;
-		}
-
-		/**
-		 * Sets the value for the failUnhealthy property
-		 * 
-		 * @param onlyStable
-		 *            The value for failUnhealthy
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setFailUnhealthy(Boolean failUnhealthy) {
-			this.failUnhealthy = failUnhealthy;
-			return this;
-		}
-
-		/**
-		 * Sets the value for the failUnstable property
-		 * 
-		 * @param onlyStable
-		 *            The value for failUnstable
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setFailUnstable(Boolean failUnstable) {
-			this.failUnstable = failUnstable;
-			return this;
-		}
-
-		/**
-		 * Sets the targets for line coverage
-		 * 
-		 * @param lineCoverage
-		 *            Targets for line coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setLineCoverage(String lineCoverage) {
-			this.lineCoverage = lineCoverage;
-			return this;
-		}
-
-		/**
-		 * Sets the targets for branch coverage
-		 * 
-		 * @param lineCoverage
-		 *            Targets for line coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setBranchCoverage(String branchCoverage) {
-			this.branchCoverage = branchCoverage;
-			return this;
-		}
-
-		/**
-		 * Sets the targets for file coverage
-		 * 
-		 * @param fileCoverage
-		 *            Targets for file coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setFileCoverage(String fileCoverage) {
-			this.fileCoverage = fileCoverage;
-			return this;
-		}		
-
-		/**
-		 * Sets the targets for package coverage
-		 * 
-		 * @param packageCoverage
-		 *            Targets for package coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setPackageCoverage(String packageCoverage) {
-			this.packageCoverage = packageCoverage;
-			return this;
-		}				
-
-		/**
-		 * Sets the targets for class coverage
-		 * 
-		 * @param classCoverage
-		 *            Targets for class coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setClassCoverage(String classCoverage) {
-			this.classCoverage = classCoverage;
-			return this;
-		}				
-
-		/**
-		 * Sets the targets for method coverage
-		 * 
-		 * @param methodCoverage
-		 *            Targets for method coverage
-		 * @return ScriptBuilder instance
-		 */
-		ScriptBuilder setMethodCoverage(String methodCoverage) {
-			this.methodCoverage = methodCoverage;
-			return this;
-		}				
-		
-		
-		/**
-		 * Gets the script as a string
-		 * 
-		 * @return The script
-		 */
-		String getScript() {
-			StringBuilder script = new StringBuilder();
-			script.append("node {\n");
-			script.append(String.format("currentBuild.result = '%s'\n", this.result));
-			script.append("step ([$class: 'CoberturaPublisher', ");
-			script.append("coberturaReportFile: '**/coverage.xml', ");
-			script.append(String.format("onlyStable: %s, ", this.onlyStable.toString()));
-			script.append(String.format("failUnhealthy: %s, ", this.failUnhealthy.toString()));
-			script.append(String.format("failUnstable: %s, ", this.failUnstable.toString()));
-			if (this.lineCoverage != null) {
-				script.append(String.format("lineCoverageTargets: '%s', ", this.lineCoverage));
-			}
-			if (this.branchCoverage != null) {
-				script.append(String.format("conditionalCoverageTargets: '%s', ", this.branchCoverage));
-			}
-			if (this.fileCoverage != null) {
-				script.append(String.format("fileCoverageTargets: '%s', ", this.fileCoverage));				
-			}
-			if (this.packageCoverage != null) {
-				script.append(String.format("packageCoverageTargets: '%s', ", this.packageCoverage));				
-			}
-			if (this.classCoverage != null) {
-				script.append(String.format("classCoverageTargets: '%s', ", this.classCoverage));				
-			}
-			if (this.methodCoverage != null) {
-				script.append(String.format("methodCoverageTargets: '%s', ", this.methodCoverage));				
-			}
-			script.append("sourceEncoding: 'ASCII'])\n");
-			script.append("}");
-			return script.toString();
-		}
-	}
-
-	@Rule
-	public JenkinsRule jenkinsRule = new JenkinsRule();
-
-	/**
-	 * Tests that a run with a report file publishes
-	 */
-	@Test
-	public void testReportFile() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
-	}
-
-	/**
-	 * Tests no report is published if coverage file isn't found
-	 */
-	@Test
-	public void testNoReportFile() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
-
-		ensureWorkspaceExists(project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogNotContains("Cobertura coverage report found.", run);
-	}
-
-	/**
-	 * Tests report is published for unstable build if onlyStable = false
-	 */
-	@Test
-	public void testUnstableOnlyStableFalse() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(
-				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
-	}
-
-	/**
-	 * Tests report is not published for unstable build if onlyStable = true
-	 */
-	@Test
-	public void testUnstableOnlyStableTrue() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(
-				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
-	}
-
-	/**
-	 * Tests no report is published for failed build if onlyStable = true
-	 */
-	@Test
-	public void testFailedOnlyStableTrue() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(
-				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
-	}
-
-	/**
-	 * Tests report is not published for failed build if onlyStable = true
-	 */
-	@Test
-	public void testFailedOnlyStableFalse() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(
-				new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not UNSTABLE or better", run);
-	}
-
-	/**
-	 * Tests failing job when unhealthy due to line coverage
-	 */
-	@Test
-	public void testLineCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,91,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Lines's health is 90.0 and set minimum health is 91.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-	}
-
-	/**
-	 * Tests job unhealthy due to line coverage passes when failUnhealthy is
-	 * false
-	 */
-	@Test
-	public void testLineCoverageUnhealthyNoFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(
-				new ScriptBuilder().setFailUnhealthy(false).setLineCoverage("91,91,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Finished: SUCCESS", run);
-		jenkinsRule.assertLogNotContains("ERROR:", run);
-	}
-
-	/**
-	 * Tests failing job when unstable due to line coverage
-	 */
-	@Test
-	public void testLineCoverageFailUnstable() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,0,91").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
-		jenkinsRule.assertLogContains("Lines's stability is 90.0 and set mininum stability is 91.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
-	}
-
-	/**
-	 * Tests job unstable due to line coverage passes when failUnstable is false
-	 */
-	@Test
-	public void testLineCoverageUnstableNoFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(
-				new ScriptBuilder().setFailUnstable(false).setLineCoverage("91,0,91").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Finished: UNSTABLE", run);
-		jenkinsRule.assertLogNotContains("ERROR:", run);
-	}
-
-	/**
-	 * Tests job succeeds when line coverage is exactly target
-	 */
-	@Test
-	public void testLineCoverageSuccess() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,90,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
-	}
-
-	/**
-	 * Tests failing job when unhealthy due to branch coverage
-	 */
-	@Test
-	public void testBranchCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,76,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Conditionals's health is 75.0 and set minimum health is 76.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-	}
-
-	/**
-	 * Tests failing job when unstable due to branch coverage
-	 */
-	@Test
-	public void testBranchCoverageFailUnstable() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,0,76").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
-		jenkinsRule.assertLogContains("Conditionals's stability is 75.0 and set mininum stability is 76.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
-	}
-
-	/**
-	 * Tests job succeeds when branch coverage is exactly target
-	 */
-	@Test
-	public void testBranchCoverageSuccess() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,75,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
-	}
-	
-	/**
-	 * Tests failing job when unhealthy due to file coverage
-	 */
-	@Test
-	public void testFileCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
-				.setFileCoverage("80,101,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Files's health is 100.0 and set minimum health is 101.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-		jenkinsRule.assertLogContains("Finished: FAILURE", run);
-	}
-
-	/**
-	 * Tests failing job when unhealthy due to package coverage
-	 */
-	@Test
-	public void testPackageCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
-				.setPackageCoverage("80,101,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Packages's health is 100.0 and set minimum health is 101.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-		jenkinsRule.assertLogContains("Finished: FAILURE", run);
-	}	
-
-	/**
-	 * Tests failing job when unhealthy due to class coverage
-	 */
-	@Test
-	public void testClassCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
-				.setClassCoverage("80,101,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Classes's health is 100.0 and set minimum health is 101.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-		jenkinsRule.assertLogContains("Finished: FAILURE", run);
-	}		
-	
-	/**
-	 * Tests failing job when unhealthy due to method coverage
-	 */
-	@Test
-	public void testMethodCoverageFail() throws Exception {
-		Jenkins jenkins = jenkinsRule.jenkins;
-		WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
-
-		project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
-				.setMethodCoverage("80,101,0").getScript()));
-
-		copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
-
-		WorkflowRun run = project.scheduleBuild2(0).get();
-		jenkinsRule.waitForCompletion(run);
-
-		jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
-		jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
-		jenkinsRule.assertLogContains("Methods's health is 100.0 and set minimum health is 101.0.", run);
-		jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
-		jenkinsRule.assertLogContains("Finished: FAILURE", run);
-	}	
-	
-	/**
-	 * Creates workspace directory if needed, and returns it
-	 * 
-	 * @param job
-	 *            The job for the workspace
-	 * @return File representing workspace directory
-	 */
-	private File ensureWorkspaceExists(WorkflowJob job) {
-		FilePath path = jenkinsRule.jenkins.getWorkspaceFor(job);
-		File directory = new File(path.getRemote());
-		directory.mkdirs();
-
-		return directory;
-	}
-
-	/**
-	 * Copies a coverage file from resources to a job's workspace directory
-	 * 
-	 * @param sourceResourceName
-	 *            The name of the resource to copy
-	 * @param targetFileName
-	 *            The name of the file in the target workspace
-	 * @param job
-	 *            The job to copy the file to
-	 * @throws IOException
-	 */
-	private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job)
-			throws IOException {
-		File directory = ensureWorkspaceExists(job);
-
-		File dest = new File(directory, targetFileName);
-		File src = new File(getClass().getResource(sourceResourceName).getPath());
-
-		FileUtils.copyFile(src, dest);
-	};
+    
+    /**
+    * Helper class to build a script with a CoverturaPublisher step
+    */
+    protected class ScriptBuilder {
+        
+        private String result = "SUCCESS";
+        private Boolean onlyStable = true;
+        private Boolean failUnhealthy = true;
+        private Boolean failUnstable = true;
+        private String lineCoverage = null;
+        private String branchCoverage = null;
+        private String fileCoverage = null;
+        private String packageCoverage = null;
+        private String classCoverage = null;
+        private String methodCoverage = null;
+        
+        /**
+        * Sets the build result for the script
+        * 
+        * @param result
+        *            The value for result
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setBuildResult(String result) {
+            this.result = result;
+            return this;
+        }
+        
+        /**
+        * Sets the value for the onlyStable property
+        * 
+        * @param onlyStable
+        *            The value for onlyStable
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setOnlyStable(Boolean onlyStable) {
+            this.onlyStable = onlyStable;
+            return this;
+        }
+        
+        /**
+        * Sets the value for the failUnhealthy property
+        * 
+        * @param onlyStable
+        *            The value for failUnhealthy
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setFailUnhealthy(Boolean failUnhealthy) {
+            this.failUnhealthy = failUnhealthy;
+            return this;
+        }
+        
+        /**
+        * Sets the value for the failUnstable property
+        * 
+        * @param onlyStable
+        *            The value for failUnstable
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setFailUnstable(Boolean failUnstable) {
+            this.failUnstable = failUnstable;
+            return this;
+        }
+        
+        /**
+        * Sets the targets for line coverage
+        * 
+        * @param lineCoverage
+        *            Targets for line coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setLineCoverage(String lineCoverage) {
+            this.lineCoverage = lineCoverage;
+            return this;
+        }
+        
+        /**
+        * Sets the targets for branch coverage
+        * 
+        * @param lineCoverage
+        *            Targets for line coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setBranchCoverage(String branchCoverage) {
+            this.branchCoverage = branchCoverage;
+            return this;
+        }
+        
+        /**
+        * Sets the targets for file coverage
+        * 
+        * @param fileCoverage
+        *            Targets for file coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setFileCoverage(String fileCoverage) {
+            this.fileCoverage = fileCoverage;
+            return this;
+        }		
+        
+        /**
+        * Sets the targets for package coverage
+        * 
+        * @param packageCoverage
+        *            Targets for package coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setPackageCoverage(String packageCoverage) {
+            this.packageCoverage = packageCoverage;
+            return this;
+        }				
+        
+        /**
+        * Sets the targets for class coverage
+        * 
+        * @param classCoverage
+        *            Targets for class coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setClassCoverage(String classCoverage) {
+            this.classCoverage = classCoverage;
+            return this;
+        }				
+        
+        /**
+        * Sets the targets for method coverage
+        * 
+        * @param methodCoverage
+        *            Targets for method coverage
+        * @return ScriptBuilder instance
+        */
+        ScriptBuilder setMethodCoverage(String methodCoverage) {
+            this.methodCoverage = methodCoverage;
+            return this;
+        }				
+        
+        
+        /**
+        * Gets the script as a string
+        * 
+        * @return The script
+        */
+        String getScript() {
+            StringBuilder script = new StringBuilder();
+            script.append("node {\n");
+            script.append(String.format("currentBuild.result = '%s'\n", this.result));
+            script.append("step ([$class: 'CoberturaPublisher', ");
+            script.append("coberturaReportFile: '**/coverage.xml', ");
+            script.append(String.format("onlyStable: %s, ", this.onlyStable.toString()));
+            script.append(String.format("failUnhealthy: %s, ", this.failUnhealthy.toString()));
+            script.append(String.format("failUnstable: %s, ", this.failUnstable.toString()));
+            if (this.lineCoverage != null) {
+                script.append(String.format("lineCoverageTargets: '%s', ", this.lineCoverage));
+            }
+            if (this.branchCoverage != null) {
+                script.append(String.format("conditionalCoverageTargets: '%s', ", this.branchCoverage));
+            }
+            if (this.fileCoverage != null) {
+                script.append(String.format("fileCoverageTargets: '%s', ", this.fileCoverage));				
+            }
+            if (this.packageCoverage != null) {
+                script.append(String.format("packageCoverageTargets: '%s', ", this.packageCoverage));				
+            }
+            if (this.classCoverage != null) {
+                script.append(String.format("classCoverageTargets: '%s', ", this.classCoverage));				
+            }
+            if (this.methodCoverage != null) {
+                script.append(String.format("methodCoverageTargets: '%s', ", this.methodCoverage));				
+            }
+            script.append("sourceEncoding: 'ASCII'])\n");
+            script.append("}");
+            return script.toString();
+        }
+    }
+    
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+    
+    /**
+    * Tests that a run with a report file publishes
+    */
+    @Test
+    public void testReportFile() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
+    }
+    
+    /**
+    * Tests no report is published if coverage file isn't found
+    */
+    @Test
+    public void testNoReportFile() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().getScript()));
+        
+        ensureWorkspaceExists(project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogNotContains("Cobertura coverage report found.", run);
+    }
+    
+    /**
+    * Tests report is published for unstable build if onlyStable = false
+    */
+    @Test
+    public void testUnstableOnlyStableFalse() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(
+        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(false).getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
+    }
+    
+    /**
+    * Tests report is not published for unstable build if onlyStable = true
+    */
+    @Test
+    public void testUnstableOnlyStableTrue() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(
+        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("UNSTABLE").setOnlyStable(true).getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
+    }
+    
+    /**
+    * Tests no report is published for failed build if onlyStable = true
+    */
+    @Test
+    public void testFailedOnlyStableTrue() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(
+        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not SUCCESS or better", run);
+    }
+    
+    /**
+    * Tests report is not published for failed build if onlyStable = true
+    */
+    @Test
+    public void testFailedOnlyStableFalse() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(
+        new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not UNSTABLE or better", run);
+    }
+    
+    /**
+    * Tests failing job when unhealthy due to line coverage
+    */
+    @Test
+    public void testLineCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,91,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Lines's health is 90.0 and set minimum health is 91.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+    }
+    
+    /**
+    * Tests job unhealthy due to line coverage passes when failUnhealthy is
+    * false
+    */
+    @Test
+    public void testLineCoverageUnhealthyNoFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(
+        new ScriptBuilder().setFailUnhealthy(false).setLineCoverage("91,91,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Finished: SUCCESS", run);
+        jenkinsRule.assertLogNotContains("ERROR:", run);
+    }
+    
+    /**
+    * Tests failing job when unstable due to line coverage
+    */
+    @Test
+    public void testLineCoverageFailUnstable() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,0,91").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
+        jenkinsRule.assertLogContains("Lines's stability is 90.0 and set mininum stability is 91.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+    }
+    
+    /**
+    * Tests job unstable due to line coverage passes when failUnstable is false
+    */
+    @Test
+    public void testLineCoverageUnstableNoFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(
+        new ScriptBuilder().setFailUnstable(false).setLineCoverage("91,0,91").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Finished: UNSTABLE", run);
+        jenkinsRule.assertLogNotContains("ERROR:", run);
+    }
+    
+    /**
+    * Tests job succeeds when line coverage is exactly target
+    */
+    @Test
+    public void testLineCoverageSuccess() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setLineCoverage("91,90,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+    }
+    
+    /**
+    * Tests failing job when unhealthy due to branch coverage
+    */
+    @Test
+    public void testBranchCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,76,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Conditionals's health is 75.0 and set minimum health is 76.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+    }
+    
+    /**
+    * Tests failing job when unstable due to branch coverage
+    */
+    @Test
+    public void testBranchCoverageFailUnstable() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,0,76").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
+        jenkinsRule.assertLogContains("Conditionals's stability is 75.0 and set mininum stability is 76.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+    }
+    
+    /**
+    * Tests job succeeds when branch coverage is exactly target
+    */
+    @Test
+    public void testBranchCoverageSuccess() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBranchCoverage("76,75,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+    }
+    
+    /**
+    * Tests failing job when unhealthy due to file coverage
+    */
+    @Test
+    public void testFileCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+        .setFileCoverage("80,101,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Files's health is 100.0 and set minimum health is 101.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("Finished: FAILURE", run);
+    }
+    
+    /**
+    * Tests failing job when unhealthy due to package coverage
+    */
+    @Test
+    public void testPackageCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+        .setPackageCoverage("80,101,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Packages's health is 100.0 and set minimum health is 101.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("Finished: FAILURE", run);
+    }	
+    
+    /**
+    * Tests failing job when unhealthy due to class coverage
+    */
+    @Test
+    public void testClassCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+        .setClassCoverage("80,101,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Classes's health is 100.0 and set minimum health is 101.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("Finished: FAILURE", run);
+    }		
+    
+    /**
+    * Tests failing job when unhealthy due to method coverage
+    */
+    @Test
+    public void testMethodCoverageFail() throws Exception {
+        Jenkins jenkins = jenkinsRule.jenkins;
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
+        
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder()
+        .setMethodCoverage("80,101,0").getScript()));
+        
+        copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
+        
+        WorkflowRun run = project.scheduleBuild2(0).get();
+        jenkinsRule.waitForCompletion(run);
+        
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
+        jenkinsRule.assertLogContains("Methods's health is 100.0 and set minimum health is 101.0.", run);
+        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("Finished: FAILURE", run);
+    }	
+    
+    /**
+    * Creates workspace directory if needed, and returns it
+    * 
+    * @param job
+    *            The job for the workspace
+    * @return File representing workspace directory
+    */
+    private File ensureWorkspaceExists(WorkflowJob job) {
+        FilePath path = jenkinsRule.jenkins.getWorkspaceFor(job);
+        File directory = new File(path.getRemote());
+        directory.mkdirs();
+        
+        return directory;
+    }
+    
+    /**
+    * Copies a coverage file from resources to a job's workspace directory
+    * 
+    * @param sourceResourceName
+    *            The name of the resource to copy
+    * @param targetFileName
+    *            The name of the file in the target workspace
+    * @param job
+    *            The job to copy the file to
+    * @throws IOException
+    */
+    private void copyCoverageFile(String sourceResourceName, String targetFileName, WorkflowJob job)
+    throws IOException {
+        File directory = ensureWorkspaceExists(job);
+        
+        File dest = new File(directory, targetFileName);
+        File src = new File(getClass().getResource(sourceResourceName).getPath());
+        
+        FileUtils.copyFile(src, dest);
+    };
 }


### PR DESCRIPTION
Addresses #67 by exposing coverage target for pipeline builds. For example, to set line coverage targets:
```
    step([$class: 'CoberturaPublisher',
          coberturaReportFile: '**/coverage.xml',
          failUnhealthy: true,
          failUnstable: true,
          lineCoverageTargets: '90.0, 80.1, 50'])
```

The meaning of each number in the lineCoverageTargets is the same as available in the non-pipeline UI, in this case:
* Report health as 100% if line coverage > 90%
* Report health as 0% if line coverage < 80.1%
* Mark build as unstable if line coverage < 50%

In addition to lineCoverageTargets, you can specify the following properties:
* packageCoverageTargets
* fileCoverageTargets
* classCoverageTargets
* methodCoverageTargets
* conditionalCoverageTargets