### PR TITLE
Publish report for failed jobs if onlyStable is false

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -371,7 +371,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
     @Override
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, final TaskListener listener)
             throws InterruptedException, IOException {
-        Result threshold = onlyStable ? Result.SUCCESS : Result.UNSTABLE;
+        Result threshold = onlyStable ? Result.SUCCESS : Result.FAILURE;
         Result buildResult = build.getResult();
         if (buildResult != null && buildResult.isWorseThan(threshold)) {
             listener.getLogger().println("Skipping Cobertura coverage report as build was not " + threshold.toString() + " or better ...");

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
@@ -148,7 +148,7 @@ public class CoberturaPublisherPipelineTest {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(true).getScript()));
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILURE").setOnlyStable(true).getScript()));
 
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
@@ -160,22 +160,22 @@ public class CoberturaPublisherPipelineTest {
     }
 
     /**
-     * Tests report is not published for failed build if onlyStable = true
+     * Tests report is published for failed build if onlyStable = false
      */
     @Test
     public void testFailedOnlyStableFalse()  throws Exception {
         Jenkins jenkins = jenkinsRule.jenkins;
         WorkflowJob project = jenkins.createProject(WorkflowJob.class, "cob-test");
 
-        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILED").setOnlyStable(false).getScript()));
+        project.setDefinition(new CpsFlowDefinition(new ScriptBuilder().setBuildResult("FAILURE").setOnlyStable(false).getScript()));
 
         copyCoverageFile("coverage-with-data.xml", "coverage.xml", project);
 
         WorkflowRun run = project.scheduleBuild2(0).get();
         jenkinsRule.waitForCompletion(run);
 
-        jenkinsRule.assertLogNotContains("Publishing Cobertura coverage report...", run);
-        jenkinsRule.assertLogContains("Skipping Cobertura coverage report as build was not UNSTABLE or better", run);
+        jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
+        jenkinsRule.assertLogContains("Cobertura coverage report found.", run);
     }
 
     /**


### PR DESCRIPTION
This addresses issue #59 

> The Consider only stable builds option says - *Include only stable builds, i.e. exclude unstable and > failed ones. *
>
> But when the job actually fails, Cobertura prints "Skipping Cobertura coverage report as build was not UNSTABLE or better ..." and quits.

This change set the threshold to FAILURE or better when the flag is set, to match option text.