### PR TITLE
Add total line count to coverage paint for programmatic usage

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/renderers/SourceCodePainter.java
+++ b/src/main/java/hudson/plugins/cobertura/renderers/SourceCodePainter.java
@@ -99,6 +99,7 @@ public class SourceCodePainter extends MasterToSlaveFileCallable<Boolean> implem
                 output.write("</tr>\n");
             }
 
+            paint.setTotalLines(line)
         } finally {
             closeQuietly(output);
             closeQuietly(bos);

--- a/src/main/java/hudson/plugins/cobertura/renderers/SourceCodePainter.java
+++ b/src/main/java/hudson/plugins/cobertura/renderers/SourceCodePainter.java
@@ -99,7 +99,7 @@ public class SourceCodePainter extends MasterToSlaveFileCallable<Boolean> implem
                 output.write("</tr>\n");
             }
 
-            paint.setTotalLines(line)
+            paint.setTotalLines(line);
         } finally {
             closeQuietly(output);
             closeQuietly(bos);

--- a/src/main/java/hudson/plugins/cobertura/targets/CoveragePaint.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoveragePaint.java
@@ -149,7 +149,7 @@ public class CoveragePaint implements Serializable {
      * @param totalLines The total number of lines in this file
      **/
     public void setTotalLines(int totalLines) {
-        self.totalLines = totalLines;
+        this.totalLines = totalLines;
     }
 
     /**

--- a/src/main/java/hudson/plugins/cobertura/targets/CoveragePaint.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoveragePaint.java
@@ -111,6 +111,8 @@ public class CoveragePaint implements Serializable {
 
     protected TIntObjectMap<CoveragePaintDetails> lines = new TIntObjectHashMap<CoveragePaintDetails>();
 
+    private int totalLines = 0;
+
     public CoveragePaint(CoverageElement source) {
 //		there were no getters against the source ...
 //      this.source = source;
@@ -139,6 +141,28 @@ public class CoveragePaint implements Serializable {
             it.advance();
             paint(it.key(), it.value());
         }
+    }
+
+    /**
+     * Setter for the property {@code totalLines}.
+     *
+     * @param totalLines The total number of lines in this file
+     **/
+    public void setTotalLines(int totalLines) {
+        self.totalLines = totalLines;
+    }
+
+    /**
+     * Returns the total number of lines in this painted file. Unlike the
+     * denominator in the ratio returned by {@link #getLineCoverage()},
+     * which only indicates the number of executable lines, this includes
+     * even non-executable lines, such as white space, comments, brackets,
+     * and more.
+     *
+     * @return value for the property {@code totalLines}.
+     **/
+    public int getTotalLines() {
+        return totalLines;
     }
 
     /**

--- a/src/test/java/hudson/plugins/cobertura/targets/CoveragePaintTest.java
+++ b/src/test/java/hudson/plugins/cobertura/targets/CoveragePaintTest.java
@@ -20,9 +20,19 @@ public class CoveragePaintTest extends TestCase {
         super(string);
     }
 
+    public void testTotalLines() {
+        CoveragePaint instance = new CoveragePaint(CoverageElement.JAVA_FILE);
+        assertEquals(0, instance.getTotalLines());
+        instance.setTotalLines(451);
+        assertEquals(451, instance.getTotalLines());
+        instance.setTotalLines(179);
+        assertEquals(179, instance.getTotalLines());
+    }
+
     public void testSerializable() throws Exception {
         CoveragePaint instance = new CoveragePaint(CoverageElement.JAVA_FILE);
         instance.paint(5, 7, 4, 5);
+        instance.setTotalLines(314);
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(instance);
@@ -32,5 +42,6 @@ public class CoveragePaintTest extends TestCase {
         CoveragePaint copy = (CoveragePaint) ois.readObject();
         assertEquals(instance.getLineCoverage(), copy.getLineCoverage());
         assertEquals(instance.getConditionalCoverage(), copy.getConditionalCoverage());
+        assertEquals(314, copy.getTotalLines());
     }
 }


### PR DESCRIPTION
As Jenkins Pipeline scripts are becoming more prevalent, programmatic usage of plugin results will become more common. In this case, the result of the Cobertura plugin invocation in the pipeline can be used to feed other plugins, or published to code review systems. In support of such ends, `CoveragePaint` was missing a bit of information: The total number of lines in the file, including non-executable lines. Absent this, our code is having to re-open and re-read every line of every source file which the `SourceCodePainter` has already opened and read, just to count the total number of lines to send to our code review system along with the coverage paint information. This simple change eliminates the duplicate file reading and makes the Cobertura results more usable in a programmatic way.

NOTE: I had planned to file a feature request for this and THEN submit the pull request for it, but the issue tracking system flagged me as spam and I am still waiting on someone to review it.