### PR TITLE
JENKINS-25781 Add common prefix to all logs

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
@@ -1,0 +1,14 @@
+package hudson.plugins.cobertura;
+
+import hudson.AbortException;
+
+/**
+ *
+ * @author jeffpearce
+ */
+public class CoberturaAbortException extends AbortException {
+    public CoberturaAbortException(String message) {
+        super("[Cobertura] " + message);
+    }
+    
+}

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -532,11 +532,11 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         Result threshold = onlyStable ? Result.SUCCESS : Result.FAILURE;
         Result buildResult = build.getResult();
         if (buildResult != null && buildResult.isWorseThan(threshold)) {
-            listener.getLogger().println("Skipping Cobertura coverage report as build was not " + threshold.toString() + " or better ...");
+            logMessage(listener, "Skipping Cobertura coverage report as build was not " + threshold.toString() + " or better ...");
             return;
         }
 
-        listener.getLogger().println("[Cobertura] Publishing Cobertura coverage report...");
+        logMessage(listener, "Publishing Cobertura coverage report...");
         final File buildCoberturaDir = build.getRootDir();
         FilePath buildTarget = new FilePath(buildCoberturaDir);
 
@@ -553,20 +553,20 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         } catch (IOException e) {
             Util.displayIOException(e, listener);
             e.printStackTrace(listener.fatalError("Unable to find coverage results"));
-            throw new AbortException("Unable to find coverage results");
+            throw new CoberturaAbortException("Unable to find coverage results");
         }
 
         if (reports.length == 0) {
-            String msg = "[Cobertura] No coverage results were found using the pattern '"
+            String msg = "No coverage results were found using the pattern '"
                     + coberturaReportFile + "' relative to '"
                     + workspace.getRemote() + "'."
                     + "  Did you enter a pattern relative to the correct directory?"
                     + "  Did you generate the XML report(s) for Cobertura?";
-            listener.getLogger().println(msg);
+            logMessage(listener, msg);
             if (failNoReports) {
-                throw new AbortException(msg);
+                throw new CoberturaAbortException(msg);
             } else {
-                listener.getLogger().println("[Cobertura] Skipped cobertura reports.");
+                logMessage(listener, "Skipped cobertura reports.");
             }
             return;
         }
@@ -579,11 +579,11 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                 Util.displayIOException(e, listener);
                 String msg = "Unable to copy coverage from " + reports[i] + " to " + buildTarget;
                 e.printStackTrace(listener.fatalError(msg));
-                throw new AbortException(msg);
+                throw new CoberturaAbortException(msg);
             }
         }
 
-        listener.getLogger().println("Publishing Cobertura coverage results...");
+        logMessage(listener, "Publishing Cobertura coverage results...");
         Set<String> sourcePaths = new HashSet<String>();
         CoverageResult result = null;
         for (File coberturaXmlReport : getCoberturaReports(build)) {
@@ -592,11 +592,11 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
             } catch (IOException e) {
                 Util.displayIOException(e, listener);
                 e.printStackTrace(listener.fatalError("Unable to parse " + coberturaXmlReport));
-                throw new AbortException("Unable to parse " + coberturaXmlReport);
+                throw new CoberturaAbortException("Unable to parse " + coberturaXmlReport);
             }
         }
         if (result != null) {
-            listener.getLogger().println("Cobertura coverage report found.");
+            logMessage(listener, "Cobertura coverage report found.");
             result.setOwner(build);
             final FilePath paintedSourcesPath = new FilePath(new File(build.getParent().getRootDir(), "cobertura"));
             paintedSourcesPath.mkdirs();
@@ -623,25 +623,25 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
             build.addAction(action);
             Set<CoverageMetric> failingMetrics = failingTarget.getFailingMetrics(result);
             if (!failingMetrics.isEmpty()) {
-                listener.getLogger().println("Code coverage enforcement failed for the following metrics:");
+                logMessage(listener, "Code coverage enforcement failed for the following metrics:");
                 float oldStabilityPercent;
                 float setStabilityPercent;
                 for (CoverageMetric metric : failingMetrics) {
                     oldStabilityPercent = failingTarget.getObservedPercent(result, metric);
                     setStabilityPercent = failingTarget.getSetPercent(result, metric);
-                    listener.getLogger().println("    " + metric.getName() + "'s stability is " + roundDecimalFloat(oldStabilityPercent * 100f) + " and set mininum stability is " + roundDecimalFloat(setStabilityPercent * 100f) + ".");
+                    logMessage(listener, "    " + metric.getName() + "'s stability is " + roundDecimalFloat(oldStabilityPercent * 100f) + " and set mininum stability is " + roundDecimalFloat(setStabilityPercent * 100f) + ".");
                 }
                 if (!getFailUnstable()) {
-                    listener.getLogger().println("Setting Build to unstable.");
+                    logMessage(listener, "Setting Build to unstable.");
                     build.setResult(Result.UNSTABLE);
                 } else {
-                    throw new AbortException("Failing build due to unstability.");
+                    throw new CoberturaAbortException("Failing build due to unstability.");
                 }
             }
             if (getFailUnhealthy()) {
                 Set<CoverageMetric> unhealthyMetrics = unhealthyTarget.getFailingMetrics(result);
                 if (!unhealthyMetrics.isEmpty()) {
-                    listener.getLogger().println("Unhealthy for the following metrics:");
+                    logMessage(listener, "Unhealthy for the following metrics:");
                     float oldHealthyPercent;
                     float setHealthyPercent;
                     for (CoverageMetric metric : unhealthyMetrics) {
@@ -649,7 +649,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                         setHealthyPercent = unhealthyTarget.getSetPercent(result, metric);
                         listener.getLogger().println("    " + metric.getName() + "'s health is " + roundDecimalFloat(oldHealthyPercent * 100f) + " and set minimum health is " + roundDecimalFloat(setHealthyPercent * 100f) + ".");
                     }
-                    throw new AbortException("Failing build because it is unhealthy.");
+                    throw new CoberturaAbortException("Failing build because it is unhealthy.");
                 }
             }
             if (build.getResult() == null || build.getResult() == Result.SUCCESS) {
@@ -662,7 +662,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                 }
             }
         } else {
-            throw new AbortException("No coverage results were successfully parsed.  Did you generate "
+            throw new CoberturaAbortException("No coverage results were successfully parsed.  Did you generate "
                     + "the XML report(s) for Cobertura?");
         }
     }
@@ -671,14 +671,14 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
      * Parses any coverage strings provided to the plugin and sets the
      * coverage targets.
      * 
-     * @throws AbortException
+     * @throws CoberturaAbortException
      */
-    private void setAllCoverageTargets() throws AbortException {
+    private void setAllCoverageTargets() throws CoberturaAbortException {
       if (lineCoverageTargets != null) {
         try {
           setCoverageTargets(CoverageMetric.LINE, lineCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for lineCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for lineCoverageTargets");
         }
       }
 
@@ -686,7 +686,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         try {
           setCoverageTargets(CoverageMetric.PACKAGES, packageCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for packageCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for packageCoverageTargets");
         }
       }
 
@@ -694,7 +694,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         try {
           setCoverageTargets(CoverageMetric.FILES, fileCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for fileCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for fileCoverageTargets");
         }
       }
 
@@ -702,7 +702,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         try {
           setCoverageTargets(CoverageMetric.CLASSES, classCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for classCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for classCoverageTargets");
         }
       }
 
@@ -710,7 +710,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         try {
           setCoverageTargets(CoverageMetric.METHOD, methodCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for methodCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for methodCoverageTargets");
         }
       }
 
@@ -718,7 +718,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         try {
           setCoverageTargets(CoverageMetric.CONDITIONAL, conditionalCoverageTargets);
         } catch (NumberFormatException e) {
-          throw new AbortException("Invalid value for conditionalCoverageTargets");
+          throw new CoberturaAbortException("Invalid value for conditionalCoverageTargets");
         }
       }      
     }
@@ -787,6 +787,14 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                 }
             }
         }
+    }
+    
+    static private void logMessage(TaskListener listener, String message) {
+        listener.getLogger().printf("%s%n", wrappedMessage(message));
+    }
+    
+    static private String wrappedMessage(String message) {
+        return String.format("[Cobertura] %s%n", message);
     }
 
     /**

--- a/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaPublisherPipelineTest.java
@@ -313,7 +313,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Lines's health is 90.0 and set minimum health is 91.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
     }
     
     /**
@@ -356,7 +356,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
         jenkinsRule.assertLogContains("Lines's stability is 90.0 and set mininum stability is 91.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build due to unstability.", run);
     }
     
     /**
@@ -397,7 +397,7 @@ public class CoberturaPublisherPipelineTest {
         
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
-        jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogNotContains("ERROR:", run);
     }
     
     /**
@@ -418,7 +418,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Conditionals's health is 75.0 and set minimum health is 76.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
     }
     
     /**
@@ -439,7 +439,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Code coverage enforcement failed for the following metrics:", run);
         jenkinsRule.assertLogContains("Conditionals's stability is 75.0 and set mininum stability is 76.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build due to unstability.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build due to unstability.", run);
     }
     
     /**
@@ -459,7 +459,7 @@ public class CoberturaPublisherPipelineTest {
         
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogNotContains("Unhealthy for the following metrics:", run);
-        jenkinsRule.assertLogNotContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogNotContains("ERROR:", run);
     }
     
     /**
@@ -481,7 +481,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Files's health is 100.0 and set minimum health is 101.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
         jenkinsRule.assertLogContains("Finished: FAILURE", run);
     }
     
@@ -504,7 +504,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Packages's health is 100.0 and set minimum health is 101.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
         jenkinsRule.assertLogContains("Finished: FAILURE", run);
     }	
     
@@ -527,7 +527,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Classes's health is 100.0 and set minimum health is 101.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
         jenkinsRule.assertLogContains("Finished: FAILURE", run);
     }		
     
@@ -550,7 +550,7 @@ public class CoberturaPublisherPipelineTest {
         jenkinsRule.assertLogContains("Publishing Cobertura coverage report...", run);
         jenkinsRule.assertLogContains("Unhealthy for the following metrics:", run);
         jenkinsRule.assertLogContains("Methods's health is 100.0 and set minimum health is 101.0.", run);
-        jenkinsRule.assertLogContains("ERROR: Failing build because it is unhealthy.", run);
+        jenkinsRule.assertLogContains("ERROR: [Cobertura] Failing build because it is unhealthy.", run);
         jenkinsRule.assertLogContains("Finished: FAILURE", run);
     }	
     


### PR DESCRIPTION
Make sure all logs (including AbortException) contain the [Cobertura] prefix. This just extends what we were already doing, and adds some helper functions to make it more likely copy/pasted code will do this as well: Example output:

```[Cobertura] Publishing Cobertura coverage report...
[Cobertura] Publishing Cobertura coverage results...
[Cobertura] Cobertura coverage report found.
[Cobertura] Unhealthy for the following metrics:
    Lines's health is 90.0 and set minimum health is 99.0.
    Conditionals's health is 75.0 and set minimum health is 99.0.
...
ERROR: [Cobertura] Failing build because it is unhealthy.
Finished: FAILURE```

This addresses JENKINS-25781