### PR TITLE
JENKINS-47639 Display a message when missing coverage fails build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
     <workflow-jenkins-plugin.version>1.11</workflow-jenkins-plugin.version>
   </properties>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
   <scm>
    <connection>scm:git:git://github.com/jenkinsci/cobertura-plugin.git</connection>
    <developerConnection>scm:git:git@github.com:jenkinsci/cobertura-plugin.git</developerConnection>
@@ -217,4 +224,3 @@
     </pluginRepository>
   </pluginRepositories>
 </project>
-

--- a/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
@@ -7,11 +7,10 @@ import hudson.AbortException;
  * a common prefix to the abort message.
  */
 public class CoberturaAbortException extends AbortException {
-  /**
-   * CoberturaAbortException constructor
-   * @param  String message       the abort message
-   * @return        CoberturaAbortException 
-   */
+    /**
+     * CoberturaAbortException constructor
+     * @param  message   the abort message
+     */
     public CoberturaAbortException(String message) {
         super("[Cobertura] " + message);
     }

--- a/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
@@ -3,12 +3,17 @@ package hudson.plugins.cobertura;
 import hudson.AbortException;
 
 /**
- *
- * @author jeffpearce
+ * Common abort exception that should be thrown to abort the build. Prepends
+ * a common prefix to the abort message.
  */
 public class CoberturaAbortException extends AbortException {
+  /**
+   * CoberturaAbortException constructor
+   * @param  String message       the abort message
+   * @return        CoberturaAbortException 
+   */
     public CoberturaAbortException(String message) {
         super("[Cobertura] " + message);
     }
-    
+
 }

--- a/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaAbortException.java
@@ -14,5 +14,4 @@ public class CoberturaAbortException extends AbortException {
     public CoberturaAbortException(String message) {
         super("[Cobertura] " + message);
     }
-
 }

--- a/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaBuildAction.java
@@ -17,7 +17,6 @@ import jenkins.tasks.SimpleBuildStep;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -42,19 +41,21 @@ public class CoberturaBuildAction implements HealthReportingAction, StaplerProxy
     private transient Run<?, ?> owner;
     private CoverageTarget healthyTarget;
     private CoverageTarget unhealthyTarget;
-    private boolean failUnhealthy;
-    private boolean failUnstable;
-    private boolean autoUpdateHealth;
-    private boolean autoUpdateStability;
-    private boolean zoomCoverageChart;
-    private int maxNumberOfBuilds;
+    private final boolean failUnhealthy;
+    private final boolean failUnstable;
+    private final boolean autoUpdateHealth;
+    private final boolean autoUpdateStability;
+    private final boolean zoomCoverageChart;
+    private final int maxNumberOfBuilds;
     /**
      * Overall coverage result.
      */
     private Map<CoverageMetric, Ratio> result;
     private HealthReport health = null;
     private transient WeakReference<CoverageResult> report;
-    private boolean onlyStable;
+    private final boolean onlyStable;
+    
+    private String failMessage = null;
 
     /**
      * {@inheritDoc}
@@ -157,6 +158,25 @@ public class CoberturaBuildAction implements HealthReportingAction, StaplerProxy
             }
         }
     }
+
+    /**
+     * Getter for property 'failMessage'
+     * 
+     * @return Value for property 'failMessage'
+     */
+    public String getFailMessage() {
+        return failMessage;
+    }
+
+    /**
+     * Setter for property 'failMessage'
+     * 
+     * @param failMessage value to set for 'failMessage'
+     */
+    public void setFailMessage(String failMessage) {
+        this.failMessage = failMessage;
+    }
+
 
     public Map<CoverageMetric, Ratio> getResults() {
         return result;

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -42,7 +42,6 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
-import jdk.nashorn.internal.ir.BreakableNode;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
@@ -635,6 +634,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                     listener.getLogger().println("Setting Build to unstable.");
                     build.setResult(Result.UNSTABLE);
                 } else {
+                    action.setFailMessage(String.format("Build failed because following metrics did not meet stability target: %s.", failingMetrics.toString()));
                     throw new AbortException("Failing build due to unstability.");
                 }
             }
@@ -649,6 +649,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
                         setHealthyPercent = unhealthyTarget.getSetPercent(result, metric);
                         listener.getLogger().println("    " + metric.getName() + "'s health is " + roundDecimalFloat(oldHealthyPercent * 100f) + " and set minimum health is " + roundDecimalFloat(setHealthyPercent * 100f) + ".");
                     }
+                    action.setFailMessage(String.format("Build failed because following metrics did not meet health target: %s.", unhealthyMetrics.toString()));
                     throw new AbortException("Failing build because it is unhealthy.");
                 }
             }

--- a/src/main/resources/hudson/plugins/cobertura/CoberturaBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/CoberturaBuildAction/summary.jelly
@@ -11,6 +11,12 @@
                 &amp;nbsp;
             </j:forEach>
             </div>
+            <j:set var="failMessage" value="${it.failMessage}" />
+            <j:if test="${failMessage != null}">
+            <div style="margin: 0 0 0 1ex">
+                ${failMessage}
+            </div>
+            </j:if>
         </j:if>
     </t:summary>
 </j:jelly>


### PR DESCRIPTION
This addresses [JENKINS-47639] by saving the reason for failing a build in the build action, and showing it in the UI for the build.