### PR TITLE
JENKINS-8958 Code coverage color scheme not suited for color blind users

### DIFF
--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -881,6 +881,8 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
     @Symbol("cobertura")
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
+        private boolean colorBlindMode;
+
         CoverageMetric[] metrics = {
             CoverageMetric.PACKAGES,
             CoverageMetric.FILES,
@@ -888,6 +890,23 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
             CoverageMetric.METHOD,
             CoverageMetric.LINE,
             CoverageMetric.CONDITIONAL,};
+
+        /**
+         * load global config from disk
+         */
+        public DescriptorImpl(Class<? extends Publisher> clazz) {
+            super(clazz);
+            load();
+        }
+
+        /**
+         * load global config from disk
+         */
+        public DescriptorImpl() {
+            super();
+            load();
+        }
+
 
         /**
          * This human readable name is used in the configuration screen.
@@ -930,7 +949,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
          */
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            req.bindParameters(this, "cobertura.");
+            req.bindJSON(this, formData);
             save();
             return super.configure(req, formData);
         }
@@ -963,6 +982,25 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
+        }
+
+        /**
+         * Setter for property 'colorBlindMode'.
+         *
+         * @param colorBlindMode Value to set for property 'colorBlindMode'.
+         */
+        @DataBoundSetter
+        public void setColorBlindMode(boolean colorBlindMode) {
+            this.colorBlindMode = colorBlindMode;
+        }
+
+        /**
+         * Getter for property 'colorBlindMode'.
+         *
+         * @return Value for property 'colorBlindMode'.
+         */
+        public boolean getColorBlindMode() {
+            return colorBlindMode;
         }
     }
     

--- a/src/main/java/hudson/plugins/cobertura/CoverageChart.java
+++ b/src/main/java/hudson/plugins/cobertura/CoverageChart.java
@@ -2,13 +2,12 @@ package hudson.plugins.cobertura;
 
 import hudson.plugins.cobertura.targets.CoverageMetric;
 import hudson.util.ChartUtil;
-import hudson.util.ColorPalette;
 import hudson.util.DataSetBuilder;
 import hudson.util.ShiftedCategoryAxis;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.util.Map;
+import java.awt.*;
+import java.util.*;
+import java.util.List;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
@@ -29,6 +28,49 @@ public class CoverageChart
 	private CategoryDataset	dataset;
 	private int					lowerBound;
 	private int					upperBound;
+
+	private static final List<Color> customLineColor = Collections.unmodifiableList(Arrays.asList(
+			new Color(0xd65e00),
+			new Color(0x0072b2),
+			new Color(0x523105),
+			new Color(0x009e73),
+			new Color(0x56b4e9),
+			new Color(0xcc79a7)
+
+		));
+
+	private static final List<BasicStroke> customLineStroke = Collections.unmodifiableList(Arrays.asList(
+			new BasicStroke(
+					2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND
+			),
+			new BasicStroke(4.0f, // line width
+					BasicStroke.CAP_ROUND, // the decoration of ends of a BasicStroke
+					BasicStroke.JOIN_ROUND, // the decoration applied where path segement meet
+					1.0f,
+					new float[] {1.0f, 6.0f}, //the array representing the dashing pattern
+					0.0f //the offset to start the dashing pattern
+			),
+
+			new BasicStroke(
+					2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
+					1.0f, new float[] {8.0f, 6.0f}, 0.0f
+			),
+			new BasicStroke(
+					2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND
+			),
+			new BasicStroke(
+					2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
+					1.0f, new float[] {6.0f, 6.0f}, 0.0f
+			),
+			new BasicStroke(
+					2.0f, BasicStroke.CAP_SQUARE, BasicStroke.JOIN_ROUND,
+					1.0f, new float[] {2.0f, 6.0f}, 0.0f
+			)
+	));
+
+	private static final List<Boolean> customShapeVisible = Collections.unmodifiableList(Arrays.asList(
+			false, false, false, true, true, true
+	));
 
 	/**
 	 * Constructor
@@ -138,7 +180,7 @@ public class CoverageChart
 		plot.setBackgroundPaint( Color.WHITE );
 		plot.setOutlinePaint( null );
 		plot.setRangeGridlinesVisible( true );
-		plot.setRangeGridlinePaint( Color.black );
+		plot.setRangeGridlinePaint( Color.gray );
 
 		CategoryAxis domainAxis = new ShiftedCategoryAxis( null );
 		plot.setDomainAxis( domainAxis );
@@ -151,10 +193,17 @@ public class CoverageChart
 		rangeAxis.setStandardTickUnits( NumberAxis.createIntegerTickUnits() );
 		rangeAxis.setUpperBound( upperBound );
 		rangeAxis.setLowerBound( lowerBound );
-
 		final LineAndShapeRenderer renderer = (LineAndShapeRenderer) plot.getRenderer();
-		renderer.setBaseStroke( new BasicStroke( 1.5f ) );
-		ColorPalette.apply( renderer );
+
+		for (int i = 0; i < customLineColor.size(); i++)
+		{
+			Color c = customLineColor.get(i);
+			renderer.setSeriesPaint(i, c);
+			Stroke s = customLineStroke.get(i);
+			renderer.setSeriesStroke(i, s);
+			renderer.setSeriesShapesVisible(i, customShapeVisible.get(i));
+		}
+
 
 		// crop extra space around the graph
 		plot.setInsets( new RectangleInsets( 5.0, 0, 0, 5.0 ) );

--- a/src/main/java/hudson/plugins/cobertura/CoverageChart.java
+++ b/src/main/java/hudson/plugins/cobertura/CoverageChart.java
@@ -5,9 +5,13 @@ import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
 import hudson.util.ShiftedCategoryAxis;
 
-import java.awt.*;
-import java.util.*;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Stroke;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -504,16 +504,14 @@ public class CoverageResult implements Serializable, Chartable {
 
     /**
      *
-     * @return css file name according to the config of color blind mode
+     * @return whether enable color blind mode in global config
      */
-    public String getCssFileName() {
+    public boolean isEnableColorBlindMode() {
         Descriptor descriptor = Jenkins.getInstance().getDescriptor(CoberturaPublisher.class);
         if(descriptor instanceof CoberturaPublisher.DescriptorImpl) {
             CoberturaPublisher.DescriptorImpl d = (CoberturaPublisher.DescriptorImpl) descriptor;
-            if(d.getColorBlindMode()) {
-                return COLOR_BLIND_CSS_FILE;
-            }
+            return d.getColorBlindMode();
         }
-        return DEFAULT_CSS_FILE;
+        return false;
     }
 }

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -509,7 +509,7 @@ public class CoverageResult implements Serializable, Chartable {
     }
 
     /**
-     * @Since TODO
+     * @since TODO
      *
      * @return whether enable color blind mode in global config
      */

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -1,7 +1,16 @@
 package hudson.plugins.cobertura.targets;
 
-import hudson.model.*;
-import hudson.plugins.cobertura.*;
+import hudson.model.AbstractBuild;
+import hudson.model.Api;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Run;
+import hudson.plugins.cobertura.BuildUtils;
+import hudson.plugins.cobertura.Chartable;
+import hudson.plugins.cobertura.CoberturaBuildAction;
+import hudson.plugins.cobertura.CoberturaPublisher;
+import hudson.plugins.cobertura.CoverageChart;
+import hudson.plugins.cobertura.Ratio;
 import hudson.util.Graph;
 import hudson.util.TextFile;
 
@@ -40,9 +49,6 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean(defaultVisibility = 2)
 public class CoverageResult implements Serializable, Chartable {
-
-    private static final String DEFAULT_CSS_FILE = "style.css";
-    private static final String COLOR_BLIND_CSS_FILE = "style-color-blind.css";
 
     /**
      * Generated
@@ -503,6 +509,7 @@ public class CoverageResult implements Serializable, Chartable {
     }
 
     /**
+     * @Since TODO
      *
      * @return whether enable color blind mode in global config
      */

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageResult.java
@@ -1,14 +1,7 @@
 package hudson.plugins.cobertura.targets;
 
-import hudson.model.AbstractBuild;
-import hudson.model.Api;
-import hudson.model.Item;
-import hudson.model.Run;
-import hudson.plugins.cobertura.BuildUtils;
-import hudson.plugins.cobertura.Chartable;
-import hudson.plugins.cobertura.CoberturaBuildAction;
-import hudson.plugins.cobertura.CoverageChart;
-import hudson.plugins.cobertura.Ratio;
+import hudson.model.*;
+import hudson.plugins.cobertura.*;
 import hudson.util.Graph;
 import hudson.util.TextFile;
 
@@ -29,6 +22,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import jenkins.model.Jenkins;
 import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -46,6 +40,9 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean(defaultVisibility = 2)
 public class CoverageResult implements Serializable, Chartable {
+
+    private static final String DEFAULT_CSS_FILE = "style.css";
+    private static final String COLOR_BLIND_CSS_FILE = "style-color-blind.css";
 
     /**
      * Generated
@@ -503,5 +500,20 @@ public class CoverageResult implements Serializable, Chartable {
 
     public Api getApi() {
         return new Api(this);
+    }
+
+    /**
+     *
+     * @return css file name according to the config of color blind mode
+     */
+    public String getCssFileName() {
+        Descriptor descriptor = Jenkins.getInstance().getDescriptor(CoberturaPublisher.class);
+        if(descriptor instanceof CoberturaPublisher.DescriptorImpl) {
+            CoberturaPublisher.DescriptorImpl d = (CoberturaPublisher.DescriptorImpl) descriptor;
+            if(d.getColorBlindMode()) {
+                return COLOR_BLIND_CSS_FILE;
+            }
+        }
+        return DEFAULT_CSS_FILE;
     }
 }

--- a/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/CoberturaPublisher/global.jelly
@@ -1,0 +1,10 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:section title="${%Cobertura}">
+        <f:entry title="${%Color Blind Mode}" field="cobertura.colorBlindMode">
+            <f:checkbox checked="${instance.colorBlindMode}"/>
+        </f:entry>
+    </f:section>
+
+</j:jelly>

--- a/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
@@ -1,7 +1,13 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:layout xmlns:cobertura="/hudson/plugins/cobertura/tags" css="/plugin/cobertura/css/${it.getCssFileName()}" norefresh="true">
+    <l:layout xmlns:cobertura="/hudson/plugins/cobertura/tags" norefresh="true">
+        <l:header>
+            <link rel="stylesheet" type="text/css" href="/plugin/cobertura/css/style.css"/>
+            <j:if test="${it.isEnableColorBlindMode()}">
+                <link rel="stylesheet" type="text/css" href="/plugin/cobertura/css/style-color-blind.css"/>
+            </j:if>
+        </l:header>
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>${%Code Coverage}</h1>

--- a/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
+++ b/src/main/resources/hudson/plugins/cobertura/targets/CoverageResult/index.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:layout xmlns:cobertura="/hudson/plugins/cobertura/tags" css="/plugin/cobertura/css/style.css" norefresh="true">
+    <l:layout xmlns:cobertura="/hudson/plugins/cobertura/tags" css="/plugin/cobertura/css/${it.getCssFileName()}" norefresh="true">
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>${%Code Coverage}</h1>

--- a/src/main/webapp/css/style-color-blind.css
+++ b/src/main/webapp/css/style-color-blind.css
@@ -10,3 +10,10 @@ div.percentgraph span.text {
     color: #000 !important;
 }
 
+table.source tr.coverFull {
+    background-color: #009e73 !important;
+}
+
+table.source tr.coverNone {
+    background-color: #cc79a7 !important;
+}

--- a/src/main/webapp/css/style-color-blind.css
+++ b/src/main/webapp/css/style-color-blind.css
@@ -1,0 +1,123 @@
+table.source {
+    border-style: solid;
+    border-color: #bbb;
+    border-spacing: 0;
+    border-collapse: collapse;
+    border-width: 1px;
+    width: 100%;
+}
+
+table.source td {
+    border-style: solid;
+    border-color: #bbb;
+    border-spacing: 0;
+    border-collapse: collapse;
+    border-width: 0px 0px 0px 0px;
+    padding-left: 0.2em;
+    padding-right: 0.2em;
+    font-family: monospace;
+}
+
+table.source .text {
+    margin-top: -1px;
+}
+
+table.source td.line {
+    text-align: right;
+    border-width: 0px 1px 0px 0px;
+}
+
+table.source td.hits {
+    text-align: right;
+    border-width: 0px 1px 0px 0px;
+}
+
+table.source th {
+    padding-left: 0.5em;
+    font-weight: bold;
+    font-family: serif;
+    background-color: #f0f0f0;
+    border-width: 1px 1px 1px 1px;
+    text-align: left;
+}
+
+table.source tr.coverFull {
+    background-color: #dfd;
+}
+
+table.source tr.coverPart {
+    background-color: #ffd;
+}
+
+table.source tr.coverPart td.hits, table.source tr.coverNone td.hits {
+    font-weight: bold;
+}
+
+table.source tr.coverNone {
+    background-color: #fdd;
+}
+
+table.source tr.noCover {
+    background-color: #fff;
+}
+
+div.percentgraph {
+    background-color: #f0e442;
+    border: #808080 1px solid;
+    height: 1.3em;
+    margin: 0px;
+    padding: 0px;
+    width: 100px;
+}
+
+div.percentgraph div.greenbar {
+    background-color: #0072b2;
+    height: 1.3em;
+    margin: 0px;
+    padding: 0px;
+}
+
+div.percentgraph div.na {
+    background-color: #eaeaea;
+    height: 1.3em;
+    margin: 0px;
+    padding: 0px;
+}
+
+div.percentgraph span.text {
+    display: block;
+    text-align: center;
+    position: absolute;
+    width: 100px;
+    color: #000
+}
+
+table.percentgraph {
+    border: 0px;
+    font-size: 130%;
+    margin: 0px;
+    margin-left: 0px;
+    margin-right: 0px;
+    padding: 0px;
+    text-align: left;
+}
+
+table.percentgraph tr.percentgraph {
+    border: 0px;
+    margin: 0px;
+    padding: 0px;
+}
+
+table.percentgraph td.percentgraph {
+    border: 0px;
+    margin: 0px;
+    padding: 0px;
+    padding-left: 4px;
+}
+
+table.percentgraph td.data {
+    text-align: right;
+}
+.center {
+    text-align: center;
+}

--- a/src/main/webapp/css/style-color-blind.css
+++ b/src/main/webapp/css/style-color-blind.css
@@ -1,123 +1,12 @@
-table.source {
-    border-style: solid;
-    border-color: #bbb;
-    border-spacing: 0;
-    border-collapse: collapse;
-    border-width: 1px;
-    width: 100%;
-}
-
-table.source td {
-    border-style: solid;
-    border-color: #bbb;
-    border-spacing: 0;
-    border-collapse: collapse;
-    border-width: 0px 0px 0px 0px;
-    padding-left: 0.2em;
-    padding-right: 0.2em;
-    font-family: monospace;
-}
-
-table.source .text {
-    margin-top: -1px;
-}
-
-table.source td.line {
-    text-align: right;
-    border-width: 0px 1px 0px 0px;
-}
-
-table.source td.hits {
-    text-align: right;
-    border-width: 0px 1px 0px 0px;
-}
-
-table.source th {
-    padding-left: 0.5em;
-    font-weight: bold;
-    font-family: serif;
-    background-color: #f0f0f0;
-    border-width: 1px 1px 1px 1px;
-    text-align: left;
-}
-
-table.source tr.coverFull {
-    background-color: #dfd;
-}
-
-table.source tr.coverPart {
-    background-color: #ffd;
-}
-
-table.source tr.coverPart td.hits, table.source tr.coverNone td.hits {
-    font-weight: bold;
-}
-
-table.source tr.coverNone {
-    background-color: #fdd;
-}
-
-table.source tr.noCover {
-    background-color: #fff;
-}
-
 div.percentgraph {
-    background-color: #f0e442;
-    border: #808080 1px solid;
-    height: 1.3em;
-    margin: 0px;
-    padding: 0px;
-    width: 100px;
+    background-color: #f0e442 !important;
 }
 
 div.percentgraph div.greenbar {
-    background-color: #0072b2;
-    height: 1.3em;
-    margin: 0px;
-    padding: 0px;
-}
-
-div.percentgraph div.na {
-    background-color: #eaeaea;
-    height: 1.3em;
-    margin: 0px;
-    padding: 0px;
+    background-color: #0072b2 !important;
 }
 
 div.percentgraph span.text {
-    display: block;
-    text-align: center;
-    position: absolute;
-    width: 100px;
-    color: #000
+    color: #000 !important;
 }
 
-table.percentgraph {
-    border: 0px;
-    font-size: 130%;
-    margin: 0px;
-    margin-left: 0px;
-    margin-right: 0px;
-    padding: 0px;
-    text-align: left;
-}
-
-table.percentgraph tr.percentgraph {
-    border: 0px;
-    margin: 0px;
-    padding: 0px;
-}
-
-table.percentgraph td.percentgraph {
-    border: 0px;
-    margin: 0px;
-    padding: 0px;
-    padding-left: 4px;
-}
-
-table.percentgraph td.data {
-    text-align: right;
-}
-.center {
-    text-align: center;
-}


### PR DESCRIPTION
Add global config which can enable colorblind mode. 

I use a Chrome extension which simulates the website as a color vision impaired person would see. And the following is the results.
**Normal see it:**
![normal](https://user-images.githubusercontent.com/22002278/37149190-1730347e-2308-11e8-9ff2-ddebb3a3375a.png)

**Red-blind see it:**
![red-blind](https://user-images.githubusercontent.com/22002278/37149283-6edbedda-2308-11e8-8e6b-50d9610dafea.png)
**Green-blind see it:**
![green-blind](https://user-images.githubusercontent.com/22002278/37149320-8c4bb846-2308-11e8-87a5-7379826d712b.png)
**Blue-blind see it:**
![blue-blind](https://user-images.githubusercontent.com/22002278/37149489-242e527c-2309-11e8-85ec-f41c20d33ea9.png)

