### PR TITLE
JENKINS-44200: Make maven plugin optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ temp
 work
 *.iml
 .idea/
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <version>3.1.2</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.13</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <version>${workflow-jenkins-plugin.version}</version>

--- a/src/main/java/hudson/plugins/cobertura/MavenCoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/MavenCoberturaPublisher.java
@@ -237,7 +237,7 @@ public class MavenCoberturaPublisher extends MavenReporter {
     /**
      * Descriptor should be singleton.
      */
-    @Extension
+    @Extension(optional = true)
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends MavenReporterDescriptor {

--- a/src/test/java/hudson/plugins/cobertura/CoberturaCoverageParserTest.java
+++ b/src/test/java/hudson/plugins/cobertura/CoberturaCoverageParserTest.java
@@ -10,8 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
 import org.jvnet.hudson.test.Bug;
 import org.netbeans.insane.scanner.CountingVisitor;
 import org.netbeans.insane.scanner.ScannerUtils;


### PR DESCRIPTION
Adds an explicit, optional dependency for the maven plugin to get rid of load warnings. JENKINS-44200