### PR TITLE
Support cases when one file may be in multiple packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.7</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>code-coverage-api</artifactId>
-      <version>1.0.4</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
@@ -103,43 +103,55 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>4.0</version>
+      <version>6.1.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>maven-plugin</artifactId>
-      <version>3.1.2</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.13</version>
+      <version>1.18</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
-      <version>${workflow-jenkins-plugin.version}</version>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>${workflow-jenkins-plugin.version}</version>
+      <version>2.39</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.ui</groupId>
-          <artifactId>jquery-detached</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.11.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>${workflow-jenkins-plugin.version}</version>
+      <version>2.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.20</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.14</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/resources/hudson/plugins/cobertura/adapter/cobertura-to-standard.xsl
+++ b/src/main/resources/hudson/plugins/cobertura/adapter/cobertura-to-standard.xsl
@@ -1,8 +1,6 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <xsl:output method="xml"/>
-
-    <xsl:key name="filename" match="class" use="@filename"/>
 
     <xsl:template match="/">
         <report>
@@ -28,22 +26,27 @@
             <xsl:attribute name="name">
                 <xsl:value-of select="@name"/>
             </xsl:attribute>
-            <xsl:apply-templates select="classes/class[generate-id(.)=generate-id(key('filename',@filename)[1])]"/>
+            <xsl:apply-templates select="classes"/>
         </package>
     </xsl:template>
 
-    <xsl:template match="classes/class">
-        <file name="{@filename}">
-            <xsl:for-each select="key('filename', @filename)">
-                <class>
-                    <xsl:attribute name="name">
-                        <xsl:value-of select="@name"/>
-                    </xsl:attribute>
-                    <xsl:apply-templates select="methods/method"/>
-                    <xsl:apply-templates select="lines/line"/>
-                </class>
-            </xsl:for-each>
-        </file>
+    <xsl:template match="classes">
+        <xsl:for-each-group select="class" group-by="@filename">
+            <file>
+                <xsl:attribute name="name">
+                    <xsl:value-of select="current-grouping-key()"/>
+                </xsl:attribute>
+                <xsl:for-each select="current-group()">
+                    <class>
+                        <xsl:attribute name="name">
+                            <xsl:value-of select="@name"/>
+                        </xsl:attribute>
+                        <xsl:apply-templates select="methods/method"/>
+                        <xsl:apply-templates select="lines/line"/>
+                    </class>
+                </xsl:for-each>
+            </file>
+        </xsl:for-each-group>
     </xsl:template>
 
     <xsl:template match="methods/method">

--- a/src/test/java/hudson/plugins/cobertura/adapter/CoberturaReportAdapterTest.java
+++ b/src/test/java/hudson/plugins/cobertura/adapter/CoberturaReportAdapterTest.java
@@ -1,0 +1,54 @@
+package hudson.plugins.cobertura.adapter;
+
+import hudson.FilePath;
+import hudson.model.Descriptor;
+import hudson.plugins.cobertura.targets.CoverageResult;
+import io.jenkins.plugins.coverage.CoverageAction;
+import io.jenkins.plugins.coverage.adapter.CoverageAdapter;
+import io.jenkins.plugins.coverage.targets.CoverageElement;
+import io.jenkins.plugins.coverage.targets.Ratio;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Objects;
+
+public class CoberturaReportAdapterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void XSLT20Test() throws Exception {
+        String coberturaReport = "coberturaWithTheSameFileInDifferentPackages.xml";
+        StringBuilder sb = new StringBuilder();
+        sb.append("node {")
+                .append("publishCoverage(");
+
+        sb.append("adapters:[");
+
+        sb.append(String.format("coberturaAdapter(path: '%s')], sourceFileResolver: sourceFiles('NEVER_STORE')", coberturaReport));
+        sb.append(")").append("}");
+
+        WorkflowJob project = j.createProject(WorkflowJob.class, "coverage-pipeline-test");
+        FilePath workspace = j.jenkins.getWorkspaceFor(project);
+
+        Objects.requireNonNull(workspace)
+                .child(coberturaReport)
+                .copyFrom(getClass().getResourceAsStream(coberturaReport));
+
+        project.setDefinition(new CpsFlowDefinition(sb.toString(), true));
+        WorkflowRun r = Objects.requireNonNull(project.scheduleBuild2(0)).waitForStart();
+        Assert.assertNotNull(r);
+        j.assertBuildStatusSuccess(j.waitForCompletion(r));
+        CoverageAction coverageAction = r.getAction(CoverageAction.class);
+        Assert.assertNotNull(r);
+        Ratio lineCoverage = coverageAction.getResult().getCoverage(CoverageElement.LINE);
+        Assert.assertEquals(lineCoverage.toString(),"6/11");
+    }
+}

--- a/src/test/resources/hudson/plugins/cobertura/adapter/coberturaWithTheSameFileInDifferentPackages.xml
+++ b/src/test/resources/hudson/plugins/cobertura/adapter/coberturaWithTheSameFileInDifferentPackages.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-03.dtd">
+
+<coverage line-rate="0.9" branch-rate="0.75" version="1.9" timestamp="1187350905008">
+    <sources>
+        <source></source>
+    </sources>
+    <packages>
+        <package name="MyAssemblyOne" line-rate="0.6" branch-rate="0.6" complexity="3.0">
+            <classes>
+                <class name="TestClass" filename="C:\Repos\testrepo.git\TestClass.cs" line-rate="0.2" branch-rate="0.2" complexity="3.0">
+                    <methods>
+                        <method name="ProcessAction" signature="()" line-rate="0" branch-rate="0">
+                            <lines>
+                                <line number="4" hits="1" branch="false"/>
+                            </lines>
+                        </method>
+                        <method name="CheckCodeCoverage" signature="()" line-rate="1.0" branch-rate="1.0">
+                            <lines>
+                                <line number="5" hits="0" branch="false"/>
+                                <line number="6" hits="0" branch="false"/>
+                                <line number="7" hits="0" branch="false"/>
+                                <line number="8" hits="0" branch="false"/>
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="4" hits="1" branch="false"/>
+                        <line number="5" hits="0" branch="false"/>
+                        <line number="6" hits="0" branch="false"/>
+                        <line number="7" hits="0" branch="false"/>
+                        <line number="8" hits="0" branch="false"/>
+                    </lines>
+                </class>
+                <class name="AdditionalClass" filename="C:\Repos\testrepo.git\AdditionalClass.cs" line-rate="1.0" branch-rate="1.0" complexity="3.0">
+                    <methods>
+                        <method name="ProcessAction" signature="()" line-rate="1.0" branch-rate="1.0">
+                            <lines>
+                                <line number="4" hits="1" branch="false"/>
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="4" hits="1" branch="false"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="MyAssemblyTwo" line-rate="0.8" branch-rate="0.8" complexity="3.5">
+            <classes>
+                <class name="TestClass" filename="C:\Repos\testrepo.git\TestClass.cs" line-rate="0.8" branch-rate="0.8" complexity="3.5">
+                    <methods>
+                        <method name="ProcessAction" signature="()" line-rate="0" branch-rate="0">
+                            <lines>
+                                <line number="4" hits="0" branch="false"/>
+                            </lines>
+                        </method>
+                        <method name="CheckCodeCoverage" signature="()" line-rate="1.0" branch-rate="1.0">
+                            <lines>
+                                <line number="5" hits="1" branch="false"/>
+                                <line number="6" hits="1" branch="false"/>
+                                <line number="7" hits="1" branch="false"/>
+                                <line number="8" hits="1" branch="false"/>
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="4" hits="0" branch="false"/>
+                        <line number="5" hits="1" branch="false"/>
+                        <line number="6" hits="1" branch="false"/>
+                        <line number="7" hits="1" branch="false"/>
+                        <line number="8" hits="1" branch="false"/>
+                    </lines>
+                </class>
+        </classes>
+        </package>
+    </packages>
+</coverage>


### PR DESCRIPTION
Hello.

There is a tool called Coverlet which is a .NET utility that collects
code coverage information and it produces reports in Cobertura. And this
Coberura report may contain one file in different packages
(.NET assemblies). .NET allows you to reference one file in multiple
projects(assemblies). Because of this, when you use the Cobertura plugin
to publish your code coverage in Jenkins it shows it incorrect because
the plugin uses Muenchian grouping which doesn't allow you to have
one file in multiple packages, it just groups them, globally for a whole
report. Changed the xslt scheme to use the for-each-group which allows
to have one file in multiple packages.

Thank you.