### PR TITLE
Test with Java 21

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.4</version>
+    <version>1.6</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.67</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.50</version>
+    <version>4.67</version>
     <relativePath />
   </parent>
 
@@ -18,7 +18,7 @@
   <properties>
     <revision>1.18</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -58,7 +58,13 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>code-coverage-api</artifactId>
-      <version>2.0.4</version>
+      <version>3.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -109,8 +115,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>1500.ve4d05cd32975</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2102.v854b_fec19c92</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
+++ b/src/main/java/hudson/plugins/cobertura/CoberturaPublisher.java
@@ -941,7 +941,7 @@ public class CoberturaPublisher extends Recorder implements SimpleBuildStep {
      * Descriptor for {@link CoberturaPublisher}. Used as a singleton. The class is marked as public so that it can be
      * accessed from views.
      *
-     * See <tt>views/hudson/plugins/cobertura/CoberturaPublisher/*.jelly</tt> for the actual HTML fragment for the
+     * See {@code views/hudson/plugins/cobertura/CoberturaPublisher/*.jelly} for the actual HTML fragment for the
      * configuration screen.
      */
     @Extension

--- a/src/main/java/hudson/plugins/cobertura/Ratio.java
+++ b/src/main/java/hudson/plugins/cobertura/Ratio.java
@@ -6,7 +6,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
 /**
- * Represents <tt>x/y</tt> where x={@link #numerator} and y={@link #denominator}.
+ * Represents {@code x/y} where x={@link #numerator} and y={@link #denominator}.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/src/main/java/hudson/plugins/cobertura/targets/CoverageAggregationMode.java
+++ b/src/main/java/hudson/plugins/cobertura/targets/CoverageAggregationMode.java
@@ -4,7 +4,7 @@ import hudson.plugins.cobertura.Ratio;
 
 /**
  * Different ways of aggregating data series {x_1,x_2,x_3,...}, which can be represented as
- * <tt>f(...f(f(ZERO,x_1),x_2)...,x_n)</tt>
+ * {@code f(...f(f(ZERO,x_1),x_2)...,x_n)}
  *
  * @author Stephen Connolly
  * @since 22-Aug-2007 18:07:35

--- a/src/test/java/CoverageTablePortlet/CoverageTablePortletTest.java
+++ b/src/test/java/CoverageTablePortlet/CoverageTablePortletTest.java
@@ -37,7 +37,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlPage;
 
 public class CoverageTablePortletTest {
 


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Includes the following pull request:

* #196

Supersedes the following pull requests:

* #213
* #211
* #209
* #207
* #193

### Testing done

Confirmed tests pass with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
